### PR TITLE
Make arcane ore and mana gem slightly better citizens.

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/ArcaneOre.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/ArcaneOre.java
@@ -1,23 +1,19 @@
 package com.hollingsworth.arsnouveau.common.block;
 
-import net.minecraft.block.BlockRenderType;
-import net.minecraft.block.BlockState;
+import net.minecraft.block.OreBlock;
+import net.minecraft.util.math.MathHelper;
+import javax.annotation.Nonnull;
+import java.util.Random;
 
 
-public class ArcaneOre extends ModBlock{
+public class ArcaneOre extends OreBlock {
     public ArcaneOre() {
-        super("arcane_ore");
+        super(ModBlock.defaultProperties());
+        setRegistryName("arcane_ore");
     }
 
-//    @Override
-//    public BlockRenderLayer getRenderLayer() {
-//        return BlockRenderLayer.CUTOUT;
-//    }
-//
-
-
     @Override
-    public BlockRenderType getRenderType(BlockState p_149645_1_) {
-        return BlockRenderType.MODEL;
+    protected int getExperience(@Nonnull Random rand) {
+        return MathHelper.nextInt(rand, 2, 5); // same as lapis or redstone
     }
 }

--- a/src/main/resources/data/ars_nouveau/loot_tables/blocks/arcane_ore.json
+++ b/src/main/resources/data/ars_nouveau/loot_tables/blocks/arcane_ore.json
@@ -5,13 +5,42 @@
       "rolls": 1,
       "entries": [
         {
-          "type": "minecraft:item",
-          "name": "ars_nouveau:mana_gem"
-        }
-      ],
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "ars_nouveau:arcane_ore"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:ore_drops"
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "ars_nouveau:mana_gem"
+            }
+          ]
         }
       ]
     }

--- a/src/main/resources/data/forge/tags/blocks/ores/mana_gem.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/mana_gem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ars_nouveau:arcane_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems.json
+++ b/src/main/resources/data/forge/tags/items/gems.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ars_nouveau:mana_gem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems/mana_gem.json
+++ b/src/main/resources/data/forge/tags/items/gems/mana_gem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ars_nouveau:mana_gem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores.json
+++ b/src/main/resources/data/forge/tags/items/ores.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ars_nouveau:arcane_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/mana_gem.json
+++ b/src/main/resources/data/forge/tags/items/ores/mana_gem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ars_nouveau:arcane_ore"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/beacon_payment_items.json
+++ b/src/main/resources/data/minecraft/tags/items/beacon_payment_items.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ars_nouveau:arcane_ore"
+  ]
+}


### PR DESCRIPTION
Arcane ore:
 - extends OreBlock instead of ModBlock
 - adds Forge tags for classification
 - respects Silk Touch and Fortune effects
 - drops XP comparable to lapis or redstone if broken without Silk Touch

Mana gem:
 - adds Forge tags for classification
 - may be used as payment to reconfigure a beacon