### PR TITLE
Add CraftTweaker support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,6 @@ repositories {
     maven { url 'https://repo.repsy.io/mvn/gandiber/geckolib' }
 
 }
-
 dependencies {
 
     minecraft 'net.minecraftforge:forge:1.16.4-35.1.13'
@@ -125,6 +124,8 @@ dependencies {
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.16.3-4.0.1.0:api")
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.16.3-4.0.1.0")
     implementation fg.deobf('software.bernie.geckolib:forge-1.16.4-geckolib:3.0.0')
+    
+    compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.4:7.1.0.84")
 
 }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/compat/crafttweaker/EnchantingApparatusManager.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/compat/crafttweaker/EnchantingApparatusManager.java
@@ -1,0 +1,36 @@
+package com.hollingsworth.arsnouveau.common.compat.crafttweaker;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.hollingsworth.arsnouveau.api.enchanting_apparatus.EnchantingApparatusRecipe;
+import com.hollingsworth.arsnouveau.api.recipe.GlyphPressRecipe;
+import com.hollingsworth.arsnouveau.api.spell.ISpellTier;
+import com.hollingsworth.arsnouveau.setup.RecipeRegistry;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
+import org.openzen.zencode.java.ZenCodeType;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.arsnouveau.EnchantingApparatus")
+public class EnchantingApparatusManager implements IRecipeManager {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack result, IIngredient reagent, IIngredient[] pedestalItems) {
+        name = fixRecipeName(name);
+        EnchantingApparatusRecipe recipe = new EnchantingApparatusRecipe(new ResourceLocation("crafttweaker", name), Arrays.stream(pedestalItems).map(IIngredient::asVanillaIngredient).collect(Collectors.toList()), reagent.asVanillaIngredient(), result.getInternal());
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+    }
+    
+    @Override
+    public IRecipeType<EnchantingApparatusRecipe> getRecipeType() {
+        return RecipeRegistry.APPARATUS_TYPE;
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/compat/crafttweaker/GlyphPressManager.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/compat/crafttweaker/GlyphPressManager.java
@@ -1,0 +1,41 @@
+package com.hollingsworth.arsnouveau.common.compat.crafttweaker;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.hollingsworth.arsnouveau.api.recipe.GlyphPressRecipe;
+import com.hollingsworth.arsnouveau.api.spell.ISpellTier;
+import com.hollingsworth.arsnouveau.setup.RecipeRegistry;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.ResourceLocation;
+import org.openzen.zencode.java.ZenCodeType;
+
+import java.util.Arrays;
+
+@ZenRegister
+@ZenCodeType.Name("mods.arsnouveau.GlyphPress")
+public class GlyphPressManager implements IRecipeManager {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, String tier, IItemStack reagent, IItemStack output) {
+        name = fixRecipeName(name);
+        ISpellTier.Tier spellTier = null;
+        for(ISpellTier.Tier value : ISpellTier.Tier.values()) {
+            if(value.name().equalsIgnoreCase(tier)) {
+                spellTier = value;
+            }
+        }
+        if(spellTier == null) {
+            throw new IllegalArgumentException("Invalid spell tier! Valid values are: " + Arrays.toString(ISpellTier.Tier.values()));
+        }
+        GlyphPressRecipe recipe = new GlyphPressRecipe(new ResourceLocation("crafttweaker", name), spellTier, reagent.getInternal(), output.getInternal());
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+    }
+    
+    @Override
+    public IRecipeType<GlyphPressRecipe> getRecipeType() {
+        return RecipeRegistry.GLYPH_TYPE;
+    }
+}


### PR DESCRIPTION
Docs will be PR'd to the CraftTweaker Docs repo, and will be hosted on https://docs.blamejared.com

This is the script I used to test it, it should cover everything that can be done in JSON with it

Also I put CraftTweaker has a compileOnly because we don't really have an :api and I don't think you guys really want waste the CPU cycles loading more mods when deving, happy to change it though

```zenscript
<recipetype:ars_nouveau:glyph_recipe>.removeRecipe(<item:ars_nouveau:glyph_touch>);
<recipetype:ars_nouveau:glyph_recipe>.addRecipe("glyph_test", "one", <item:minecraft:dirt>, <item:minecraft:diamond>);

<recipetype:ars_nouveau:enchanting_apparatus>.removeRecipe(<item:ars_nouveau:ring_of_lesser_discount>);
<recipetype:ars_nouveau:enchanting_apparatus>.addRecipe("enchanting_test", <item:minecraft:diamond>, <item:minecraft:glass>, [<item:minecraft:dirt>, <item:minecraft:apple>, <item:minecraft:arrow>]);
```