### PR TITLE
AOE and pierce refinements

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SpellUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SpellUtil.java
@@ -23,6 +23,10 @@ public class SpellUtil {
         return calcAOEBlocks(caster, origin, mop, 1 + aoeBonus, 1 + aoeBonus, 1, -1);
     }
 
+    public static List<BlockPos> calcAOEBlocks(LivingEntity caster, BlockPos origin, BlockRayTraceResult mop, int aoeBonus, int pierceBonus) {
+        return calcAOEBlocks(caster, origin, mop, 1 + aoeBonus, 1 + aoeBonus, 1 + pierceBonus, -1);
+    }
+
     public static List<BlockPos> calcAOEBlocks(LivingEntity caster, BlockPos origin, BlockRayTraceResult mop, int width, int height, int depth, int distance) {
         return calcAOEBlocks(caster.getHorizontalFacing().getDirectionVec(), origin, mop, width, height, depth, distance);
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBreak.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBreak.java
@@ -9,6 +9,7 @@ import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtract;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentFortune;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.material.Material;
 import net.minecraft.enchantment.Enchantment;
@@ -57,7 +58,8 @@ public class EffectBreak extends AbstractEffect {
             BlockState state;
 
             int aoeBuff = getBuffCount(augments, AugmentAOE.class);
-            List<BlockPos> posList = SpellUtil.calcAOEBlocks(shooter, pos, (BlockRayTraceResult)rayTraceResult,1 + aoeBuff, 1 + aoeBuff, 1, -1);
+            int pierceBuff = getBuffCount(augments, AugmentPierce.class);
+            List<BlockPos> posList = SpellUtil.calcAOEBlocks(shooter, pos, (BlockRayTraceResult)rayTraceResult,1 + aoeBuff, 1 + aoeBuff, 1 + pierceBuff, -1);
 
             for(BlockPos pos1 : posList) {
                 state = world.getBlockState(pos1);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCrush.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCrush.java
@@ -6,6 +6,7 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.LivingEntity;
@@ -28,7 +29,7 @@ public class EffectCrush extends AbstractEffect {
 
     @Override
     public void onResolveBlock(BlockRayTraceResult rayTraceResult, World world, @Nullable LivingEntity shooter, List<AbstractAugment> augments, SpellContext spellContext) {
-        for(BlockPos p : SpellUtil.calcAOEBlocks(shooter, rayTraceResult.getPos(), rayTraceResult, getBuffCount(augments, AugmentAOE.class))){
+        for(BlockPos p : SpellUtil.calcAOEBlocks(shooter, rayTraceResult.getPos(), rayTraceResult, getBuffCount(augments, AugmentAOE.class), getBuffCount(augments, AugmentPierce.class))){
             BlockState state = world.getBlockState(p);
             if(state.getBlock().isIn(Tags.Blocks.COBBLESTONE) || state.getBlock().isIn(Tags.Blocks.STONE)){
                 world.setBlockState(p, Blocks.GRAVEL.getDefaultState());

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCut.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCut.java
@@ -7,6 +7,7 @@ import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentFortune;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.ItemEntity;
@@ -51,7 +52,7 @@ public class EffectCut extends AbstractEffect {
 
     @Override
     public void onResolveBlock(BlockRayTraceResult rayTraceResult, World world,  LivingEntity shooter, List<AbstractAugment> augments, SpellContext spellContext) {
-        for(BlockPos p : SpellUtil.calcAOEBlocks(shooter, rayTraceResult.getPos(), rayTraceResult, getBuffCount(augments, AugmentAOE.class))) {
+        for(BlockPos p : SpellUtil.calcAOEBlocks(shooter, rayTraceResult.getPos(), rayTraceResult, getBuffCount(augments, AugmentAOE.class), getBuffCount(augments, AugmentPierce.class))) {
             ItemStack shears = new ItemStack(Items.SHEARS);
             applyEnchantments(augments, shears);
             if (world.getBlockState(p).getBlock() instanceof IForgeShearable) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFell.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFell.java
@@ -37,26 +37,24 @@ public class EffectFell extends AbstractEffect {
 
     @Override
     public void onResolveBlock(BlockRayTraceResult ray, World world, @Nullable LivingEntity shooter, List<AbstractAugment> augments, SpellContext spellContext) {
-        for(BlockPos blockpos : SpellUtil.calcAOEBlocks(shooter, ray.getPos(), ray, getBuffCount(augments, AugmentAOE.class))) {
-            BlockState state = world.getBlockState(blockpos);
-            if (isTree(state)) {
-                Set<BlockPos> list = getTree(world, ray.getPos(), 50 + 50 * getBuffCount(augments, AugmentAOE.class));
-                list.forEach(listPos -> {
-                    if (!BlockUtil.destroyRespectsClaim(shooter, world, listPos))
-                        return;
-                    if (hasBuff(augments, AugmentExtract.class)) {
-                        world.getBlockState(listPos).getDrops(LootUtil.getSilkContext((ServerWorld) world, listPos, shooter)).forEach(i -> world.addEntity(new ItemEntity(world, listPos.getX(), listPos.getY(), listPos.getZ(), i)));
-                        BlockUtil.destroyBlockSafelyWithoutSound(world, listPos, false);
-                    } else if (hasBuff(augments, AugmentFortune.class)) {
-                        world.getBlockState(listPos).getDrops(LootUtil.getFortuneContext((ServerWorld) world, listPos, shooter, getBuffCount(augments, AugmentFortune.class))).forEach(i -> world.addEntity(new ItemEntity(world, listPos.getX(), listPos.getY(), listPos.getZ(), i)));
-                        BlockUtil.destroyBlockSafelyWithoutSound(world, listPos, false);
-                    } else {
-                        BlockUtil.destroyBlockSafelyWithoutSound(world, listPos, true);
-                    }
-                });
-                world.playEvent(2001, blockpos, Block.getStateId(state));
-                return;
-            }
+        BlockPos blockPos = ray.getPos();
+        BlockState state = world.getBlockState(blockPos);
+        if (isTree(state)) {
+            Set<BlockPos> list = getTree(world, blockPos, 50 + 50 * getBuffCount(augments, AugmentAOE.class));
+            list.forEach(listPos -> {
+                if (!BlockUtil.destroyRespectsClaim(shooter, world, listPos))
+                    return;
+                if (hasBuff(augments, AugmentExtract.class)) {
+                    world.getBlockState(listPos).getDrops(LootUtil.getSilkContext((ServerWorld) world, listPos, shooter)).forEach(i -> world.addEntity(new ItemEntity(world, listPos.getX(), listPos.getY(), listPos.getZ(), i)));
+                    BlockUtil.destroyBlockSafelyWithoutSound(world, listPos, false);
+                } else if (hasBuff(augments, AugmentFortune.class)) {
+                    world.getBlockState(listPos).getDrops(LootUtil.getFortuneContext((ServerWorld) world, listPos, shooter, getBuffCount(augments, AugmentFortune.class))).forEach(i -> world.addEntity(new ItemEntity(world, listPos.getX(), listPos.getY(), listPos.getZ(), i)));
+                    BlockUtil.destroyBlockSafelyWithoutSound(world, listPos, false);
+                } else {
+                    BlockUtil.destroyBlockSafelyWithoutSound(world, listPos, true);
+                }
+            });
+            world.playEvent(2001, blockPos, Block.getStateId(state));
         }
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGrow.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGrow.java
@@ -6,6 +6,7 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.IGrowable;
 import net.minecraft.entity.LivingEntity;
@@ -32,7 +33,7 @@ public class EffectGrow  extends AbstractEffect {
     @Override
     public void onResolve(RayTraceResult rayTraceResult, World world, LivingEntity shooter, List<AbstractAugment> augments, SpellContext spellContext) {
         if(rayTraceResult instanceof BlockRayTraceResult) {
-            for(BlockPos blockpos : SpellUtil.calcAOEBlocks(shooter, ((BlockRayTraceResult) rayTraceResult).getPos(), (BlockRayTraceResult) rayTraceResult, getBuffCount(augments, AugmentAOE.class))){
+            for(BlockPos blockpos : SpellUtil.calcAOEBlocks(shooter, ((BlockRayTraceResult) rayTraceResult).getPos(), (BlockRayTraceResult) rayTraceResult, getBuffCount(augments, AugmentAOE.class), getBuffCount(augments, AugmentPierce.class))){
                 //BlockPos blockpos = ((BlockRayTraceResult) rayTraceResult).getPos();
                 ItemStack stack = new ItemStack(Items.BONE_MEAL);
                 if(world instanceof ServerWorld)

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHarvest.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHarvest.java
@@ -8,6 +8,7 @@ import com.hollingsworth.arsnouveau.api.util.LootUtil;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentFortune;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import com.hollingsworth.arsnouveau.setup.BlockRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -39,7 +40,7 @@ public class EffectHarvest extends AbstractEffect {
             BlockRayTraceResult ray = (BlockRayTraceResult) rayTraceResult;
             if(world.isRemote)
                 return;
-            for(BlockPos blockpos : SpellUtil.calcAOEBlocks(shooter, ray.getPos(), ray, getBuffCount(augments, AugmentAOE.class))){
+            for(BlockPos blockpos : SpellUtil.calcAOEBlocks(shooter, ray.getPos(), ray, getBuffCount(augments, AugmentAOE.class), getBuffCount(augments, AugmentPierce.class))){
                 BlockState state = world.getBlockState(blockpos);
 
                 if(state.getBlock() instanceof FarmlandBlock || world.getBlockState(blockpos.up()).getBlock() instanceof CropsBlock){

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectIgnite.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectIgnite.java
@@ -7,6 +7,7 @@ import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import net.minecraft.block.AbstractFireBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.material.Material;
@@ -36,7 +37,7 @@ public class EffectIgnite  extends AbstractEffect {
             ((EntityRayTraceResult) rayTraceResult).getEntity().setFire(duration);
         }else if(rayTraceResult instanceof BlockRayTraceResult && world.getBlockState(((BlockRayTraceResult) rayTraceResult).getPos().up()).getMaterial() == Material.AIR){
             Direction face = ((BlockRayTraceResult) rayTraceResult).getFace();
-            for(BlockPos pos : SpellUtil.calcAOEBlocks( shooter, ((BlockRayTraceResult) rayTraceResult).getPos(), (BlockRayTraceResult)rayTraceResult, getBuffCount(augments, AugmentAOE.class))) {
+            for(BlockPos pos : SpellUtil.calcAOEBlocks( shooter, ((BlockRayTraceResult) rayTraceResult).getPos(), (BlockRayTraceResult)rayTraceResult, getBuffCount(augments, AugmentAOE.class), getBuffCount(augments, AugmentPierce.class))) {
 
                 BlockPos blockpos1 = pos.offset(face);
                 if (AbstractFireBlock.canLightBlock(world, blockpos1, face)) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSmelt.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSmelt.java
@@ -39,9 +39,10 @@ public class EffectSmelt extends AbstractEffect {
 
 
         int aoeBuff = getBuffCount(augments, AugmentAOE.class);
-        int maxItemSmelt = 3 + 4*aoeBuff;
+        int pierceBuff = getBuffCount(augments, AugmentAOE.class);
+        int maxItemSmelt = 3 + 4*aoeBuff*pierceBuff;
 
-        List<BlockPos> posList = SpellUtil.calcAOEBlocks(shooter, ((BlockRayTraceResult) rayTraceResult).getPos(), (BlockRayTraceResult)rayTraceResult,1 + aoeBuff, 1 + aoeBuff, 1, -1);
+        List<BlockPos> posList = SpellUtil.calcAOEBlocks(shooter, ((BlockRayTraceResult) rayTraceResult).getPos(), (BlockRayTraceResult)rayTraceResult,1 + aoeBuff, 1 + aoeBuff, 1 + pierceBuff, -1);
         List<ItemEntity> itemEntities = world.getEntitiesWithinAABB(ItemEntity.class, new AxisAlignedBB(((BlockRayTraceResult) rayTraceResult).getPos()).grow(aoeBuff + 1.0));
         smeltItems(world, itemEntities, maxItemSmelt);
 
@@ -74,19 +75,18 @@ public class EffectSmelt extends AbstractEffect {
 
     public void smeltItems(World world, List<ItemEntity> itemEntities, int maxItemSmelt){
         int numSmelted = 0;
-        for(int i = 0; i < itemEntities.size(); i++){
-            if( numSmelted > maxItemSmelt)
+        for (ItemEntity itemEntity : itemEntities) {
+            if (numSmelted > maxItemSmelt)
                 break;
-            ItemEntity entity = itemEntities.get(i);
-            Optional<FurnaceRecipe> optional = world.getRecipeManager().getRecipe(IRecipeType.SMELTING, new Inventory(entity.getItem()),
+            Optional<FurnaceRecipe> optional = world.getRecipeManager().getRecipe(IRecipeType.SMELTING, new Inventory(itemEntity.getItem()),
                     world);
-            if(optional.isPresent()){
+            if (optional.isPresent()) {
                 ItemStack result = optional.get().getRecipeOutput().copy();
-                if(result.isEmpty())
+                if (result.isEmpty())
                     continue;
-                while(numSmelted < maxItemSmelt && !entity.getItem().isEmpty()){
-                    entity.getItem().shrink(1);
-                    world.addEntity(new ItemEntity(world, entity.getPosX(), entity.getPosY(), entity.getPosZ(), result.copy()));
+                while (numSmelted < maxItemSmelt && !itemEntity.getItem().isEmpty()) {
+                    itemEntity.getItem().shrink(1);
+                    world.addEntity(new ItemEntity(world, itemEntity.getPosX(), itemEntity.getPosY(), itemEntity.getPosZ(), result.copy()));
                     numSmelted++;
                 }
             }


### PR DESCRIPTION
- For multiple block-affecting effects that accept AOE to expand parallel to the struck surface, pierce expands deeper into the struck surface.
- Fell no longer performs initial AOE expansion, since it self-expands by tracing connected fellable blocks.