### PR TITLE
Change minecraft:chest to forge:chest

### DIFF
--- a/src/main/resources/data/ars_nouveau/patchouli_books/worn_notebook/en_us/entries/apparatus/sylph_charm.json
+++ b/src/main/resources/data/ars_nouveau/patchouli_books/worn_notebook/en_us/entries/apparatus/sylph_charm.json
@@ -37,7 +37,7 @@
 	"type":"multiblock",
 	"multiblock":{
 		"mapping":{
-			"C":"minecraft:chest",
+			"C":"forge:chest",
 			"0":"ars_nouveau:summoning_crystal",
 			"J":"ars_nouveau:mana_jar"
 		},

--- a/src/main/resources/data/ars_nouveau/patchouli_books/worn_notebook/ko_kr/entries/apparatus/sylph_charm.json
+++ b/src/main/resources/data/ars_nouveau/patchouli_books/worn_notebook/ko_kr/entries/apparatus/sylph_charm.json
@@ -37,7 +37,7 @@
 	"type":"multiblock",
 	"multiblock":{
 		"mapping":{
-			"C":"minecraft:chest",
+			"C":"forge:chest",
 			"0":"ars_nouveau:summoning_crystal",
 			"J":"ars_nouveau:mana_jar"
 		},

--- a/src/main/resources/data/ars_nouveau/recipes/allow_scroll.json
+++ b/src/main/resources/data/ars_nouveau/recipes/allow_scroll.json
@@ -5,7 +5,7 @@
       "item": "ars_nouveau:blank_parchment"
     },
     {
-      "item": "minecraft:chest"
+      "item": "forge:chest"
     }
   ],
   "result": {


### PR DESCRIPTION
While using mods such as Quark that added their own chests/remove vanilla chest crafting, crafting of void jar becomes impossible. This should fix this by checking for forge:chest instead of minecraft:chest. Also adds the same functionality to sylph charm multiblock.