### PR TITLE
Default to true if a spellPart isn't found

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/setup/Config.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/setup/Config.java
@@ -52,7 +52,7 @@ public class Config {
     private static Map<String, ForgeConfigSpec.IntValue> spellCost = new HashMap<>();
 
     public static boolean isSpellEnabled(String tag){
-        return enabledSpells.get(tag).get();
+        return enabledSpells.containsKey(tag) ? enabledSpells.get(tag).get() : true;
     }
 
     public static int getSpellCost(String tag){


### PR DESCRIPTION
Changing this line'll default to true whenever a glyph is added by an addon that *isn't* in the default Config, preventing an NPE crash for addons that add new glpyhs and spell parts.