### PR TITLE
Add Constructor without predetermined Properties

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellBook.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellBook.java
@@ -62,6 +62,11 @@ public class SpellBook extends Item implements ISpellTier, IScribeable, IDisplay
         super(new Item.Properties().maxStackSize(1).group(ArsNouveau.itemGroup).setISTER(() -> SpellBookRenderer::new));
         this.tier = tier;
     }
+    
+    public SpellBook(Properties properties, Tier tier) {
+        super(properties);
+        this.tier = tier;
+    }
 
     @Override
     public boolean isDamageable() {


### PR DESCRIPTION
This small change just adds a constructor that allows new types of spellbooks to change from the default renderer without interfering with existing functionality c: