### PR TITLE
Implemented validation and glyph count limitations

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/ArsNouveauAPI.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/ArsNouveauAPI.java
@@ -10,6 +10,8 @@ import com.hollingsworth.arsnouveau.api.ritual.AbstractRitual;
 import com.hollingsworth.arsnouveau.api.ritual.RitualContext;
 import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
 import com.hollingsworth.arsnouveau.api.spell.ISpellTier;
+import com.hollingsworth.arsnouveau.api.spell.ISpellValidator;
+import com.hollingsworth.arsnouveau.common.spell.validation.StandardSpellValidator;
 import com.hollingsworth.arsnouveau.common.block.tile.RitualTile;
 import com.hollingsworth.arsnouveau.common.items.Glyph;
 import com.hollingsworth.arsnouveau.common.items.RitualTablet;
@@ -32,6 +34,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Main class of the Ars Nouveau API.
+ *
+ * Obtain an instance with {@link ArsNouveauAPI#getInstance()}.
+ */
 public class ArsNouveauAPI {
 
 
@@ -63,6 +70,11 @@ public class ArsNouveauAPI {
      * Contains the list of parchment item instances created during registration
      */
     private HashMap<String, RitualTablet> ritualParchmentMap;
+
+    /** Validator to use when crafting a spell in the spell book. */
+    private ISpellValidator craftingSpellValidator;
+    /** Validator to use when casting a spell. */
+    private ISpellValidator castingSpellValidator;
 
     private List<IEnchantingRecipe> enchantingApparatusRecipes;
     /**
@@ -213,6 +225,23 @@ public class ArsNouveauAPI {
         return brewingRecipes;
     }
 
+    /**
+     * Returns the {@link ISpellValidator} that enforces the standard rules for spell crafting.
+     * This validator relaxes the rule about starting with a cast method, to allow for spells that will be imprinted
+     * onto caster items, which generally have a built-in cast method.
+     */
+    public ISpellValidator getSpellCraftingSpellValidator() {
+        return craftingSpellValidator;
+    }
+
+    /**
+     * Returns the {@link ISpellValidator} that enforces the standard rules for spells at cast time.
+     * This validator enforces all rules, asserting that a spell can be cast.
+     */
+    public ISpellValidator getSpellCastingSpellValidator() {
+        return castingSpellValidator;
+    }
+
     private ArsNouveauAPI(){
         spell_map = new HashMap<>();
         glyphMap = new HashMap<>();
@@ -220,13 +249,15 @@ public class ArsNouveauAPI {
         enchantingApparatusRecipes = new ArrayList<>();
         ritualMap = new HashMap<>();
         ritualParchmentMap = new HashMap<>();
+        craftingSpellValidator = new StandardSpellValidator(false);
+        castingSpellValidator = new StandardSpellValidator(true);
     }
 
-    public static ArsNouveauAPI getInstance(){
-        if(arsNouveauAPI == null)
-            arsNouveauAPI = new ArsNouveauAPI();
+    /** Retrieves a handle to the singleton instance. */
+    public static ArsNouveauAPI getInstance() {
         return arsNouveauAPI;
     }
 
-    private static ArsNouveauAPI arsNouveauAPI = null;
+    // This is needed internally by the mod, so just make it eagerly.
+    private static final ArsNouveauAPI arsNouveauAPI = new ArsNouveauAPI();
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCastMethod.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCastMethod.java
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemUseContext;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -29,6 +30,11 @@ public abstract class AbstractCastMethod extends AbstractSpellPart {
 
     public abstract boolean wouldCastOnEntitySuccessfully(@Nullable ItemStack stack, LivingEntity caster, LivingEntity target, Hand hand, List<AbstractAugment> augments);
 
+    @Override
+    public void buildConfig(ForgeConfigSpec.Builder builder) {
+        super.buildConfig(builder);
+        super.buildAugmentLimitsConfig(builder, getDefaultAugmentLimits());
+    }
 
     public AbstractCastMethod(String tag, String description){
         super(tag,description);

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
@@ -191,6 +191,7 @@ public abstract class AbstractEffect extends AbstractSpellPart {
     @Override
     public void buildConfig(ForgeConfigSpec.Builder builder) {
         super.buildConfig(builder);
+        super.buildAugmentLimitsConfig(builder, getDefaultAugmentLimits());
     }
 
     public void addDamageConfig(ForgeConfigSpec.Builder builder, double defaultValue){

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
@@ -146,7 +146,11 @@ public abstract class AbstractSpellPart implements ISpellTier, Comparable<Abstra
         return "";
     }
 
+    public String getLocalizationKey() {
+        return "ars_nouveau.glyph_name." + tag;
+    }
+
     public String getLocaleName(){
-        return new TranslationTextComponent("ars_nouveau.glyph_name." + tag).getString();
+        return new TranslationTextComponent(getLocalizationKey()).getString();
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/ISpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/ISpellValidator.java
@@ -1,0 +1,20 @@
+package com.hollingsworth.arsnouveau.api.spell;
+
+import java.util.List;
+
+/**
+ * Interface describing a spell validator.  Validators are functions that analyze a spell and indicate if the spell
+ * violates the rules defined by the specific implementation of this interface.
+ *
+ * This interface is not intended to be implemented by clients of the API.
+ */
+public interface ISpellValidator {
+    /**
+     * Validates the given spell recipe.
+     *
+     * @param spellRecipe the recipe of the spell to validate. The list may contain <code>null</code> elements, which
+     *                    indicates that a glyph slot is currently blank.
+     * @return a list of any {@link SpellValidationError}s found.
+     */
+    List<SpellValidationError> validate(List<AbstractSpellPart> spellRecipe);
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/ISpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/ISpellValidator.java
@@ -6,6 +6,8 @@ import java.util.List;
  * Interface describing a spell validator.  Validators are functions that analyze a spell and indicate if the spell
  * violates the rules defined by the specific implementation of this interface.
  *
+ * Clients should obtain an instance of this interface from {@link com.hollingsworth.arsnouveau.api.ArsNouveauAPI}.
+ *
  * This interface is not intended to be implemented by clients of the API.
  */
 public interface ISpellValidator {

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/SpellValidationError.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/SpellValidationError.java
@@ -1,0 +1,39 @@
+package com.hollingsworth.arsnouveau.api.spell;
+
+import net.minecraft.util.text.IFormattableTextComponent;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * An indication of some sort of validation error when confirming if a spell is correctly constructed.
+ *
+ * Instances of this are obtained from {@link ISpellValidator#validate(List)}.
+ *
+ * This interface is not intended to be implemented by clients of the API.
+ */
+public interface SpellValidationError {
+    /**
+     * Returns the position this validation error refers to, or <code>-1</code> if the error indicates a problem with
+     * the entire spell.
+     */
+    int getPosition();
+
+    /**
+     * Returns the spell part this validation error refers to, or <code>null</code> if the error indicates a problem
+     * with the entire spell.
+     */
+    @Nullable
+    AbstractSpellPart getSpellPart();
+
+    /**
+     * Creates and returns a Text Component with a full error message, where the use case is reporting an issue with
+     * an existing glyph.
+     */
+    IFormattableTextComponent makeTextComponentExisting();
+    /**
+     * Creates and returns a Text Component with a full error message, where the use case is reporting an issue that
+     * will occur if adding a glyph to a spell.
+     */
+    IFormattableTextComponent makeTextComponentAdding();
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/ModdedScreen.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/ModdedScreen.java
@@ -16,7 +16,7 @@ public class ModdedScreen extends Screen {
 
     public int maxScale;
     public float scaleFactor;
-    public List<String> tooltip;
+    public List<ITextComponent> tooltip;
 
     public ModdedScreen(ITextComponent titleIn) {
         super(titleIn);
@@ -46,14 +46,8 @@ public class ModdedScreen extends Screen {
         return mouseX >= x && mouseX <= x + w && mouseY >= y && mouseY <= y + h;
     }
     public final void drawTooltip(MatrixStack stack, int mouseX, int mouseY) {
-        if(tooltip != null) {
-            FontRenderer font = Minecraft.getInstance().font;
-            this.renderTooltip(stack,new StringTextComponent(tooltip.get(0)), mouseX, mouseY);
-
-        } else if(tooltip != null && !tooltip.isEmpty()) {
-            List<String> wrappedTooltip = new ArrayList<>();
-            for (String s : tooltip)
-                Collections.addAll(wrappedTooltip, s.split("\n"));
+        if (tooltip != null && !tooltip.isEmpty()) {
+            this.renderWrappedToolTip(stack, tooltip, mouseX, mouseY, font);
         }
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/CraftingButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/CraftingButton.java
@@ -5,9 +5,10 @@ import com.hollingsworth.arsnouveau.client.gui.book.GuiSpellBook;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.*;
 import org.lwjgl.opengl.GL11;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 public class CraftingButton extends GuiImageButton{
@@ -35,9 +36,9 @@ public class CraftingButton extends GuiImageButton{
             if(parent.isMouseInRelativeRange(parX, parY, x, y, width, height)){
 
                 if(parent.api.getSpell_map().containsKey(this.spellTag)) {
-                    List<String> test = new ArrayList<>();
-                    test.add(parent.api.getSpell_map().get(this.spellTag).name);
-                    parent.tooltip = test;
+                    List<ITextComponent> tooltip = new LinkedList<>();
+                    tooltip.add(new TranslationTextComponent(parent.api.getSpell_map().get(this.spellTag).getLocalizationKey()));
+                    parent.tooltip = tooltip;
                 }
             }
         }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/CraftingButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/CraftingButton.java
@@ -1,6 +1,7 @@
 package com.hollingsworth.arsnouveau.client.gui.buttons;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
 import com.hollingsworth.arsnouveau.client.gui.book.GuiSpellBook;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.gui.widget.button.Button;
@@ -15,20 +16,32 @@ public class CraftingButton extends GuiImageButton{
     int slotNum;
     public String spellTag;
     public String resourceIcon;
+    public List<SpellValidationError> validationErrors;
 
     public CraftingButton(GuiSpellBook parent, int x, int y, int slotNum, Button.IPressable onPress) {
         super( x, y, 0, 0, 22, 20, 22, 20, "textures/gui/spell_glyph_slot.png", onPress);
         this.slotNum = slotNum;
         this.spellTag = "";
         this.resourceIcon = "";
+        this.validationErrors = new LinkedList<>();
         this.parent = parent;
+    }
+
+    public void clear() {
+        this.spellTag = "";
+        this.resourceIcon = "";
+        this.validationErrors.clear();
     }
 
     @Override
     public void render(MatrixStack ms, int parX, int parY, float partialTicks) {
         if (visible)
         {
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            if (validationErrors.isEmpty()) {
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            } else {
+                GL11.glColor4f(1.0F, 0.7F, 0.7F, 1.0F);
+            }
             //GuiSpellBook.drawFromTexture(new ResourceLocation(ExampleMod.MODID, this.resourceIcon), x, y, 0, 0, 20, 20, 20, 20);
             if(!this.resourceIcon.equals("")){
                 GuiSpellBook.drawFromTexture(new ResourceLocation(ArsNouveau.MODID, "textures/items/" + resourceIcon), x + 3, y + 2, u, v, 16, 16, 16, 16,ms);
@@ -38,6 +51,9 @@ public class CraftingButton extends GuiImageButton{
                 if(parent.api.getSpell_map().containsKey(this.spellTag)) {
                     List<ITextComponent> tooltip = new LinkedList<>();
                     tooltip.add(new TranslationTextComponent(parent.api.getSpell_map().get(this.spellTag).getLocalizationKey()));
+                    for (SpellValidationError ve : validationErrors) {
+                        tooltip.add(ve.makeTextComponentExisting().withStyle(TextFormatting.RED));
+                    }
                     parent.tooltip = tooltip;
                 }
             }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/CreateSpellButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/CreateSpellButton.java
@@ -1,0 +1,64 @@
+package com.hollingsworth.arsnouveau.client.gui.buttons;
+
+import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+import com.hollingsworth.arsnouveau.client.gui.book.GuiSpellBook;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.gui.widget.button.Button;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.TranslationTextComponent;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CreateSpellButton extends GuiImageButton {
+    private final ResourceLocation image = new ResourceLocation(ArsNouveau.MODID, "textures/gui/create_icon.png");
+
+    public CreateSpellButton(GuiSpellBook parent, int x, int y, Button.IPressable onPress) {
+        super(x, y, 0,0,50, 12, 50, 12, "textures/gui/create_icon.png", onPress);
+        this.parent = parent;
+    }
+
+    @Override
+    public void render(MatrixStack ms, int parX, int parY, float partialTicks) {
+        if (visible) {
+            if (parent.validationErrors.isEmpty()) {
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            } else {
+                GL11.glColor4f(1.0F, 0.7F, 0.7F, 1.0F);
+            }
+
+            GuiSpellBook.drawFromTexture(image, x, y, u, v, width, height, image_width, image_height, ms);
+
+            if (parent.isMouseInRelativeRange(parX, parY, x, y, width, height)) {
+                if (!parent.validationErrors.isEmpty()) {
+                    List<ITextComponent> tooltip = new ArrayList<>();
+                    boolean foundGlyphErrors = false;
+
+                    tooltip.add(new TranslationTextComponent("ars_nouveau.spell.validation.crafting.invalid").withStyle(TextFormatting.RED));
+
+                    // Add any spell-wide errors
+                    for (SpellValidationError error : parent.validationErrors) {
+                        if (error.getPosition() < 0) {
+                            tooltip.add(error.makeTextComponentExisting());
+                        } else {
+                            foundGlyphErrors = true;
+                        }
+                    }
+
+                    // Show a single placeholder for all the per-glyph errors
+                    if (foundGlyphErrors) {
+                        tooltip.add(new TranslationTextComponent("ars_nouveau.spell.validation.crafting.invalid_glyphs"));
+                    }
+
+                    parent.tooltip = tooltip;
+                }
+            }
+        }
+        // We've handled all of the required rendering at this point.  No need to call super.
+        //super.render(ms, parX, parY, partialTicks);
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
@@ -1,9 +1,9 @@
 package com.hollingsworth.arsnouveau.client.gui.buttons;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
 import com.hollingsworth.arsnouveau.client.gui.book.GuiSpellBook;
 import com.mojang.blaze3d.matrix.MatrixStack;
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
@@ -12,8 +12,10 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 @OnlyIn(Dist.CLIENT)
@@ -24,6 +26,7 @@ public class GlyphButton extends Button {
     public String spell_id; //Reference to a spell ID for spell crafting
     private int id;
     public String tooltip = "tooltip";
+    public List<SpellValidationError> validationErrors;
 
     GuiSpellBook parent;
 
@@ -38,11 +41,13 @@ public class GlyphButton extends Button {
         this.resourceIcon = resource_image;
         this.spell_id = spell_id;
         this.id = 0;
+        this.validationErrors = new LinkedList<>();
     }
 
     public GlyphButton(GuiSpellBook parent, int x, int y, boolean isCraftingSlot, String resource_image, String spell_id, Integer id) {
         this(parent, x, y, isCraftingSlot, resource_image, spell_id);
         this.id = id;
+        this.validationErrors = new LinkedList<>();
     }
 
     public int getId() {
@@ -59,9 +64,15 @@ public class GlyphButton extends Button {
         if (visible)
         {
             if(this.resourceIcon != null && !this.resourceIcon.equals("")) {
-                RenderSystem.color3f(1F, 1F, 1F);
+                GL11.glEnable(GL11.GL_BLEND);
+                if (validationErrors.isEmpty()) {
+                    GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+                } else {
+                    GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.25F);
+                }
 
                 GuiSpellBook.drawFromTexture(new ResourceLocation(ArsNouveau.MODID, "textures/items/" + this.resourceIcon), x, y, 0, 0, 16, 16,16,16 , ms);
+                GL11.glDisable(GL11.GL_BLEND);
             }
 
             if(parent.isMouseInRelativeRange(mouseX, mouseY, x, y, width, height)){
@@ -69,6 +80,9 @@ public class GlyphButton extends Button {
                 if(parent.api.getSpell_map().containsKey(this.spell_id)) {
                     List<ITextComponent> tip = new ArrayList<>();
                     tip.add(new TranslationTextComponent(parent.api.getSpell_map().get(this.spell_id).getLocalizationKey()));
+                    for (SpellValidationError ve : validationErrors) {
+                        tip.add(ve.makeTextComponentAdding().withStyle(TextFormatting.RED));
+                    }
                     parent.tooltip = tip;
                 }
             }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
@@ -7,6 +7,9 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -64,9 +67,9 @@ public class GlyphButton extends Button {
             if(parent.isMouseInRelativeRange(mouseX, mouseY, x, y, width, height)){
 
                 if(parent.api.getSpell_map().containsKey(this.spell_id)) {
-                    List<String> test = new ArrayList<>();
-                    test.add(parent.api.getSpell_map().get(this.spell_id).getLocaleName());
-                    parent.tooltip = test;
+                    List<ITextComponent> tip = new ArrayList<>();
+                    tip.add(new TranslationTextComponent(parent.api.getSpell_map().get(this.spell_id).getLocalizationKey()));
+                    parent.tooltip = tip;
                 }
             }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GuiImageButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GuiImageButton.java
@@ -55,14 +55,5 @@ public class GuiImageButton extends Button
             GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
             GuiSpellBook.drawFromTexture(image, x, y, u, v, width, height, image_width, image_height,ms);
         }
-        if(isHovered){
-            String name = "hi";
-            if(!name.isEmpty()){
-                List<String> tip = new ArrayList<>();
-                tip.add(name);
-                parent.tooltip = tip;
-            }
-        }
-
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GuiSpellSlot.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GuiSpellSlot.java
@@ -6,6 +6,8 @@ import com.hollingsworth.arsnouveau.common.items.SpellBook;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
@@ -34,8 +36,8 @@ public class GuiSpellSlot extends GuiImageButton {
             if(parent.isMouseInRelativeRange(parX, parY, x, y, width, height)){
                 String name = SpellBook.getSpellName(parent.spell_book_tag, slotNum);
                 if(!name.isEmpty()){
-                    List<String> tip = new ArrayList<>();
-                    tip.add(name);
+                    List<ITextComponent> tip = new ArrayList<>();
+                    tip.add(new StringTextComponent(name));
                     parent.tooltip = tip;
                 }
             }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/AbstractSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/AbstractSpellValidator.java
@@ -1,0 +1,31 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.ISpellValidator;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Abstract base class for ISpellValidators that handles some common boilerplate.
+ */
+public abstract class AbstractSpellValidator implements ISpellValidator {
+    @Override
+    public List<SpellValidationError> validate(List<AbstractSpellPart> spellRecipe) {
+        List<SpellValidationError> errors = new LinkedList<>();
+        validateImpl(spellRecipe, errors);
+        return errors;
+    }
+
+    /**
+     * Implementations of this method validate the given spell recipe, accumulating errors into <code>validationErrors</code>.
+     *
+     * @param spellRecipe the recipe of the spell to validate. The list may contain <code>null</code> elements, which
+     *                    indicates that a glyph slot is currently blank.
+     * @param validationErrors a list the validator may add new errors to. Like <code>context</code>, this list is
+     *                         private to the specific validator, allowing steps to remove or change existing errors if
+     *                         desired.
+     */
+    protected abstract void validateImpl(List<AbstractSpellPart> spellRecipe, List<SpellValidationError> validationErrors);
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/ActionAugmentationPolicyValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/ActionAugmentationPolicyValidator.java
@@ -1,0 +1,47 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+import com.hollingsworth.arsnouveau.setup.Config;
+
+import java.util.List;
+
+/**
+ * Spell validation that enforces the augmentation limits per action (cast method or effect) set out in the configuration.
+ */
+public class ActionAugmentationPolicyValidator extends SpellPhraseValidator {
+    @Override
+    protected void validatePhrase(SpellPhrase phrase, List<SpellValidationError> errors) {
+        // No validation of augments without the effect present
+        AbstractSpellPart action = phrase.getAction();
+        if (action != null) {
+            phrase.getAugmentPositionMap().forEach((augmentTag, augments) -> {
+                int limit = action.getAugmentLimit(augmentTag);
+                if (augments.size() > limit) {
+                    // Iterate, but skip until the limit, then mark the rest.
+                    for (int i = limit; i < augments.size(); i++) {
+                        errors.add(new ActionAugmentationPolicyValidationError(
+                                augments.get(i).position,
+                                augments.get(i).spellPart,
+                                action,
+                                limit
+                        ));
+                    }
+                }
+            });
+        }
+    }
+
+    private static class ActionAugmentationPolicyValidationError extends BaseSpellValidationError {
+        public ActionAugmentationPolicyValidationError(int position, AbstractAugment augment, AbstractSpellPart action, int limit) {
+            super(
+                    position,
+                    augment,
+                    limit <= 0 ? "action_augmentation_policy.zero" : "action_augmentation_policy",
+                    action,
+                    augment
+            );
+        }
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/BaseSpellValidationError.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/BaseSpellValidationError.java
@@ -1,0 +1,111 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+import net.minecraft.util.text.IFormattableTextComponent;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base class for common logic when constructing a {@link SpellValidationError}.
+ *
+ * Provides logic around finding the exact localization keys and for building text components that translate both
+ * the core message and the glyphs being passed as arguments.
+ *
+ * Subclasses of this base class will seek localization keys under
+ * <code>"ars_nouveau.spell.validation.exists."</code>
+ * or <code>"ars_nouveau.spell.validation.adding."</code>.
+ */
+public class BaseSpellValidationError implements SpellValidationError {
+    private static final ITextComponent[] NO_ARGS = new ITextComponent[0];
+    private final int position;
+    private final AbstractSpellPart spellPart;
+    private final String localizationCode;
+    private final Object[] translationArguments;
+
+    /**
+     * Creates a new Spell Validation Error.
+     *
+     * @param position the glyph position in the overall spell that was validated.
+     * @param spellPart the actual spell part in the offending position
+     * @param localizationCode the localization code
+     * @param translationArguments arguments to be passed to the i18n system when constructing text components for this
+     *                             error.
+     * @see TranslationTextComponent
+     */
+    public BaseSpellValidationError(int position,
+                                    AbstractSpellPart spellPart,
+                                    String localizationCode,
+                                    ITextComponent... translationArguments) {
+        this.position = position;
+        this.spellPart = spellPart;
+        this.localizationCode = localizationCode;
+        this.translationArguments = translationArguments;
+    }
+
+    /**
+     * Creates a new Spell Validation Error.
+     *
+     * @param position the glyph position in the overall spell that was validated.
+     * @param spellPart the actual spell part in the offending position
+     * @param localizationCode the localization code
+     */
+    public BaseSpellValidationError(int position,
+                                    AbstractSpellPart spellPart,
+                                    String localizationCode) {
+        this(position, spellPart, localizationCode, NO_ARGS);
+    }
+
+    /**
+     * Creates a new Spell Validation Error.
+     *
+     * @param position the glyph position in the overall spell that was validated.
+     * @param spellPart the actual spell part in the offending position
+     * @param localizationCode the localization code
+     * @param spellParts arguments to be passed to the i18n system when constructing text components for this error.
+     */
+    public BaseSpellValidationError(int position,
+                                    AbstractSpellPart spellPart,
+                                    String localizationCode,
+                                    AbstractSpellPart... spellParts) {
+        this(position, spellPart, localizationCode, translateGlyphs(spellParts));
+    }
+
+    @Override
+    public int getPosition() {
+        return position;
+    }
+
+    @Nullable
+    @Override
+    public AbstractSpellPart getSpellPart() {
+        return spellPart;
+    }
+
+    @Override
+    public IFormattableTextComponent makeTextComponentExisting() {
+        return makeTextComponent("ars_nouveau.spell.validation.exists.");
+    }
+    @Override
+    public IFormattableTextComponent makeTextComponentAdding() {
+        return makeTextComponent("ars_nouveau.spell.validation.adding.");
+    }
+
+    private IFormattableTextComponent makeTextComponent(String keyPrefix) {
+        return new TranslationTextComponent(keyPrefix + localizationCode, translationArguments);
+    }
+
+    /**
+     * Translates a number of spell parts into an array of ITextComponents suitable for use as the arguments
+     * parameter of the constructor.
+     */
+    private static ITextComponent[] translateGlyphs(AbstractSpellPart... parts) {
+        ITextComponent[] textComponents = new ITextComponent[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            textComponents[i] = new TranslationTextComponent(parts[i].getLocalizationKey());
+        }
+        return textComponents;
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/CombinedSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/CombinedSpellValidator.java
@@ -1,0 +1,34 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.ISpellValidator;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Combined spell validator that runs the validations of all its children.
+ */
+public class CombinedSpellValidator implements ISpellValidator {
+    private final List<ISpellValidator> validators;
+
+    /** Create a combined spell validator from the given list of validators. */
+    public CombinedSpellValidator(List<ISpellValidator> validators) {
+        this.validators = validators;
+    }
+
+    /** Create a combined spell validator from the given list of validators. */
+    public CombinedSpellValidator(ISpellValidator... validators) {
+        this.validators = Arrays.asList(validators);
+    }
+
+    @Override
+    public List<SpellValidationError> validate(List<AbstractSpellPart> spellRecipe) {
+        return validators.stream()
+                .flatMap(v -> v.validate(spellRecipe).stream())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/GlyphMaxTierValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/GlyphMaxTierValidator.java
@@ -1,0 +1,40 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+import net.minecraft.util.Unit;
+
+import java.util.List;
+
+/**
+ * Spell validation that enforces that glyphs be equal to or of a lesser tier than the provided one.
+ *
+ * This validator is pulled in specially in {@link com.hollingsworth.arsnouveau.client.gui.book.GuiSpellBook}.
+ */
+public class GlyphMaxTierValidator extends ScanningSpellValidator<Unit> {
+    private final int maxTier;
+
+    /** Creates a glyph tier validator that will only accept glyphs of <code><maxTier/code> or <em>lower</em>. */
+    public GlyphMaxTierValidator(int maxTier) {
+        this.maxTier = maxTier;
+    }
+
+    @Override
+    protected Unit initContext() { return Unit.INSTANCE; }
+
+    @Override
+    protected void digestSpellPart(Unit context, int position, AbstractSpellPart spellPart, List<SpellValidationError> validationErrors) {
+        if (spellPart.getTier().ordinal() > maxTier) {
+            validationErrors.add(new GlyphTierValidationError(position, spellPart, "glyph_tier"));
+        }
+    }
+
+    @Override
+    protected void finish(Unit context, List<SpellValidationError> validationErrors) {}
+
+    private static class GlyphTierValidationError extends BaseSpellValidationError {
+        public GlyphTierValidationError(int position, AbstractSpellPart spellPart, String localizationCode) {
+            super(position, spellPart, localizationCode, spellPart);
+        }
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/GlyphOccurrencesPolicyValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/GlyphOccurrencesPolicyValidator.java
@@ -1,0 +1,49 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+import com.hollingsworth.arsnouveau.setup.Config;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spell validation that enforces the glyph limits policy set out in the configuration.
+ */
+public class GlyphOccurrencesPolicyValidator extends ScanningSpellValidator<Map<String, Integer>> {
+    @Override
+    protected Map<String, Integer> initContext() {
+        return new HashMap<>();
+    }
+
+    @Override
+    protected void digestSpellPart(Map<String, Integer> partCounts, int position, AbstractSpellPart spellPart, List<SpellValidationError> validationErrors) {
+        // Count the glyph
+        if (partCounts.containsKey(spellPart.tag)) {
+            partCounts.put(spellPart.tag, partCounts.get(spellPart.tag) + 1);
+        } else {
+            partCounts.put(spellPart.tag, 1);
+        }
+
+        // Check if over the limit
+        int limit = spellPart.PER_SPELL_LIMIT.get();
+        if (partCounts.getOrDefault(spellPart.tag, 0) > limit) {
+            validationErrors.add(new GlyphOccurrencesPolicySpellValidationError(position, spellPart, limit));
+        }
+    }
+
+    @Override
+    protected void finish(Map<String, Integer> context, List<SpellValidationError> validationErrors) {}
+
+    private static class GlyphOccurrencesPolicySpellValidationError extends BaseSpellValidationError {
+        public GlyphOccurrencesPolicySpellValidationError(int position, AbstractSpellPart part, int limit) {
+            super(
+                    position,
+                    part,
+                    "glyph_occurrences_policy",
+                    part
+            );
+        }
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/MaxOneCastMethodSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/MaxOneCastMethodSpellValidator.java
@@ -1,0 +1,39 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractCastMethod;
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import java.util.List;
+
+/**
+ * Spell validation that requires at most one cast method in a spell.
+ */
+public class MaxOneCastMethodSpellValidator extends ScanningSpellValidator<MaxOneCastMethodSpellValidator.OneCastContext> {
+    @Override
+    protected OneCastContext initContext() {
+        return new OneCastContext();
+    }
+
+    @Override
+    protected void digestSpellPart(OneCastContext context, int position, AbstractSpellPart spellPart, List<SpellValidationError> validationErrors) {
+        if (spellPart instanceof AbstractCastMethod) {
+            context.count++;
+            if (context.count > 1) {
+                validationErrors.add(new OneCastMethodSpellValidationError(position, (AbstractCastMethod) spellPart));
+            }
+        }
+    }
+
+    @Override
+    protected void finish(OneCastContext context, List<SpellValidationError> validationErrors) {}
+
+    /** Context for this validator is a simple counter on AbstractCastMethod parts */
+    public static class OneCastContext { int count = 0; }
+
+    private static class OneCastMethodSpellValidationError extends BaseSpellValidationError {
+        public OneCastMethodSpellValidationError(int position, AbstractCastMethod method) {
+            super(position, method, "max_one_cast_method", method);
+        }
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/NonEmptySpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/NonEmptySpellValidator.java
@@ -1,0 +1,22 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import java.util.List;
+
+/** Spell validator that asserts that the spell is non-empty. */
+public class NonEmptySpellValidator extends AbstractSpellValidator {
+    @Override
+    protected void validateImpl(List<AbstractSpellPart> spellRecipe, List<SpellValidationError> validationErrors) {
+        if (spellRecipe == null || spellRecipe.isEmpty()) {
+            validationErrors.add(new NonEmptySpellValidationError());
+        }
+    }
+
+    private static class NonEmptySpellValidationError extends BaseSpellValidationError {
+        public NonEmptySpellValidationError() {
+            super(-1, null, "non_empty_spell");
+        }
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/ScanningSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/ScanningSpellValidator.java
@@ -1,0 +1,57 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.ISpellValidator;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A scanning spell validator operates by scanning over the spell glyph by glyph from left to right, collecting any
+ * errors found during the process.
+ *
+ * The design of this class ensures that the actual <code>ScanningSpellValidator</code> object is immutable, while still
+ * allowing mutable state during spell validation.
+ */
+public abstract class ScanningSpellValidator<T> implements ISpellValidator {
+    /** Called to initialize a new context for a validation job. */
+    protected abstract T initContext();
+
+    /**
+     * Called to validate the given spell part, accumulating any state in <code>context</code> and adding
+     * any discovered validation errors to <code>errorAccumulator</code>.
+     *
+     * @param context the context the stateful validator stores its state in
+     * @param position the position within the spell recipe this glyph appears in
+     * @param spellPart the current glyph being validated
+     * @param validationErrors a list the validator may add new errors to. Like <code>context</code>, this list is
+     *                         private to the specific validator, allowing steps to remove or change existing errors if
+     *                         desired.
+     */
+    protected abstract void digestSpellPart(T context, int position, AbstractSpellPart spellPart, List<SpellValidationError> validationErrors);
+
+    /**
+     * Called to complete validation after all glyphs have been consumed for validation.
+     *
+     * @param context the final context at the end of validation
+     * @param validationErrors a list the finisher may add new errors to. Like <code>context</code>, this list is
+     *                         private to the specific job, allowing steps to remove or change existing errors if desired.
+     */
+    protected abstract void finish(T context, List<SpellValidationError> validationErrors);
+
+    @Override
+    public List<SpellValidationError> validate(List<AbstractSpellPart> spellRecipe) {
+        T t = initContext();
+        List<SpellValidationError> errors = new LinkedList<>();
+
+        for(int pos = 0; pos < spellRecipe.size(); pos++) {
+            AbstractSpellPart part = spellRecipe.get(pos);
+            if (part != null) {
+               digestSpellPart(t, pos, part, errors);
+            }
+        }
+        finish(t, errors);
+        return errors;
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/SpellPhraseValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/SpellPhraseValidator.java
@@ -1,0 +1,149 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+/**
+ * A type of spell validator that validates a spell as a set of individual <em>phrases</em> where a spell phrase is any
+ * action (cast form or effect) modified by a series of augments.
+ *
+ * Implementations of this class should be warned that positions may be <code>null</code>, which occurs while crafting
+ * spells if there are gaps in the UI.
+ *
+ * The augment position map will exclude empty slots.
+ */
+public abstract class SpellPhraseValidator extends AbstractSpellValidator {
+    /**
+     * Implemented to define the per-phrase validation logic.
+     *
+     * @param phrase the spell phrase to validate
+     * @param validationErrors a list the validator may add new errors to. Like <code>context</code>, this list is
+     *                         private to the specific validator, allowing steps to remove or change existing errors if
+     *                         desired.
+     */
+    protected abstract void validatePhrase(SpellPhrase phrase, List<SpellValidationError> validationErrors);
+
+    @Override
+    protected void validateImpl(List<AbstractSpellPart> spellRecipe, List<SpellValidationError> validationErrors) {
+        List<SpellPhrase> phrases = splitSpellIntoPhrases(spellRecipe);
+
+        for (SpellPhrase phrase : phrases) {
+            validatePhrase(phrase, validationErrors);
+        }
+    }
+
+    /**
+     * Creates a list of SpellValidationPhrases from a spell recipe.
+     *
+     * @param recipe the spell recipe to break into phrases.
+     */
+    public static List<SpellPhrase> splitSpellIntoPhrases(List<AbstractSpellPart> recipe) {
+        List<SpellPhrase> phrases = new LinkedList<>();
+
+        // Initialize the accumulators
+        AbstractSpellPart action = null;
+        List<AbstractAugment> augments = new ArrayList<>();
+        Map<String, List<SpellPhrase.SpellPartPosition<AbstractAugment>>> augmentPositionMap = new LinkedHashMap<>();
+        int phraseStart = 0;
+
+        // Walk through the recipe
+        for (int pos = 0; pos < recipe.size(); pos++) {
+            AbstractSpellPart currentPart = recipe.get(pos);
+            if (currentPart instanceof AbstractAugment) {
+                // Still in a phrase, add to the augment list
+                augments.add((AbstractAugment) currentPart);
+
+                // Note the position as well for easy lookup in the phrase validator
+                if (!augmentPositionMap.containsKey(currentPart.tag)) {
+                    augmentPositionMap.put(currentPart.tag, new LinkedList<>());
+                }
+                augmentPositionMap.get(currentPart.tag).add(new SpellPhrase.SpellPartPosition<>((AbstractAugment) currentPart, pos));
+            } else {
+                // Action changed, wrap up the current phrase and add it to the list
+                phrases.add(new SpellPhrase(action, augments, augmentPositionMap, phraseStart));
+
+                // Reset the accumulators
+                action = currentPart;
+                augments = new LinkedList<>();
+                phraseStart = pos;
+            }
+        }
+        // Be sure to grab the last one
+        phrases.add(new SpellPhrase(action, augments, augmentPositionMap, phraseStart));
+
+        return phrases;
+    }
+
+    /**
+     * Class representing a single <em>phrase</em> of a spell. A phrase is either a cast method or an effect, followed
+     * by zero or more augments.
+     */
+    public static class SpellPhrase {
+        private final int firstPosition;
+        private final AbstractSpellPart action;
+        private final List<AbstractAugment> augments;
+        private final Map<String, List<SpellPartPosition<AbstractAugment>>> augmentPositionMap;
+
+        /**
+         * Create a new phrase that contains an action (a cast method or an effect) followed by zero or more augments.
+         *
+         * @param action             the action that starts this phrase. If null, this phrase has no action. This is valid
+         *                           for spells in the spell book that are intended to be applied to an item that has a cast
+         *                           method.
+         * @param augments           a list of augment spell parts that make up the rest of the phrase.
+         * @param augmentPositionMap a map from augment tags to a list of pairs of spell parts and their positions within
+         *                           the overall spell.
+         * @param firstPosition      the position (0 index) of the first action glyph within the overall spell recipe.
+         */
+        private SpellPhrase(@Nullable AbstractSpellPart action, List<AbstractAugment> augments, Map<String, List<SpellPartPosition<AbstractAugment>>> augmentPositionMap, int firstPosition) {
+            this.firstPosition = firstPosition;
+            this.action = action;
+            this.augments = augments;
+            this.augmentPositionMap = augmentPositionMap;
+        }
+
+        public static final class SpellPartPosition<T extends AbstractSpellPart> {
+            final T spellPart;
+            final int position;
+
+            public SpellPartPosition(T spellPart, int position) {
+                this.spellPart = spellPart;
+                this.position = position;
+            }
+        }
+
+        /**
+         * Returns the action that begins this phrase, if present.
+         */
+        @Nullable
+        public AbstractSpellPart getAction() {
+            return action;
+        }
+
+        /**
+         * Returns the raw list of augments that make up this phrase.
+         */
+        public List<AbstractAugment> getAugments() {
+            return augments;
+        }
+
+        /**
+         * Returns the (0 based) index of the first glyph of this phrase within the overall spell recipe
+         */
+        public int getFirstPosition() {
+            return firstPosition;
+        }
+
+        /**
+         * Returns a map from augment tags to a list of pairs of {@link AbstractAugment} and their positions in the overall
+         * spell being validated. The contained lists will always be in ascending position order.
+         */
+        public Map<String, List<SpellPartPosition<AbstractAugment>>> getAugmentPositionMap() {
+            return augmentPositionMap;
+        }
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StandardSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StandardSpellValidator.java
@@ -11,6 +11,8 @@ import java.util.*;
  *
  * That is to say if it contains all the required elements to be cast, and that it does not violate any configured
  * limits to spell construction such as limits on the number of times a given glyph may appear.
+ *
+ * Instances of this class should be obtained from {@link com.hollingsworth.arsnouveau.api.ArsNouveauAPI}.
  */
 public class StandardSpellValidator implements ISpellValidator {
     // Validators are static and immutable. It's safe to eagerly construct these and pull them in when a validator is requested.

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StandardSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StandardSpellValidator.java
@@ -1,0 +1,50 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.ISpellValidator;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import java.util.*;
+
+/**
+ * Primary class containing the logic to decide if a spell's recipe is <em>valid</em>.
+ *
+ * That is to say if it contains all the required elements to be cast, and that it does not violate any configured
+ * limits to spell construction such as limits on the number of times a given glyph may appear.
+ */
+public class StandardSpellValidator implements ISpellValidator {
+    // Validators are static and immutable. It's safe to eagerly construct these and pull them in when a validator is requested.
+    private static final ISpellValidator MAX_ONE_CAST_METHOD = new MaxOneCastMethodSpellValidator();
+    private static final ISpellValidator NON_EMPTY_SPELL = new NonEmptySpellValidator();
+    private static final ISpellValidator REQUIRE_CAST_METHOD_START = new StartingCastMethodSpellValidator();
+
+    private final ISpellValidator combinedValidator;
+
+    /**
+     * Creates a standard spell recipe validator that enforces all standard rules.
+     *
+     * @param enforceCastTimeValidations if <code>true</code>, the spell must be valid for casting, which enables
+     *                                   validations for having exactly one cast method as the first glyph. Pass
+     *                                   <code>false</code>, when validating for spell crafting.
+     */
+    public StandardSpellValidator(boolean enforceCastTimeValidations) {
+        List<ISpellValidator> validators = new LinkedList<>();
+
+        // Unconditional validators
+        validators.add(MAX_ONE_CAST_METHOD);
+
+        // Validators only applicable at casting time
+        if (enforceCastTimeValidations) {
+            validators.add(NON_EMPTY_SPELL);
+            validators.add(REQUIRE_CAST_METHOD_START);
+        }
+
+        // Combine them all together.
+        this.combinedValidator = new CombinedSpellValidator(validators);
+    }
+
+    @Override
+    public List<SpellValidationError> validate(List<AbstractSpellPart> spellRecipe) {
+        return combinedValidator.validate(spellRecipe);
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StandardSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StandardSpellValidator.java
@@ -19,6 +19,8 @@ public class StandardSpellValidator implements ISpellValidator {
     private static final ISpellValidator MAX_ONE_CAST_METHOD = new MaxOneCastMethodSpellValidator();
     private static final ISpellValidator NON_EMPTY_SPELL = new NonEmptySpellValidator();
     private static final ISpellValidator REQUIRE_CAST_METHOD_START = new StartingCastMethodSpellValidator();
+    private static final ISpellValidator GLYPH_OCCURRENCES_POLICY = new GlyphOccurrencesPolicyValidator();
+    private static final ISpellValidator EFFECT_AUGMENTATION_POLICY = new ActionAugmentationPolicyValidator();
 
     private final ISpellValidator combinedValidator;
 
@@ -34,6 +36,8 @@ public class StandardSpellValidator implements ISpellValidator {
 
         // Unconditional validators
         validators.add(MAX_ONE_CAST_METHOD);
+        validators.add(GLYPH_OCCURRENCES_POLICY);
+        validators.add(EFFECT_AUGMENTATION_POLICY);
 
         // Validators only applicable at casting time
         if (enforceCastTimeValidations) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StartingCastMethodSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StartingCastMethodSpellValidator.java
@@ -1,0 +1,25 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractCastMethod;
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import java.util.List;
+
+/**
+ * Spell validation that requires a spell start with a cast method.
+ */
+public class StartingCastMethodSpellValidator extends AbstractSpellValidator {
+    @Override
+    protected void validateImpl(List<AbstractSpellPart> spellRecipe, List<SpellValidationError> errors) {
+        if (!(spellRecipe.isEmpty() || spellRecipe.get(0) instanceof AbstractCastMethod)) {
+            errors.add(new StartingCastMethodSpellValidationError());
+        }
+    }
+
+    private static class StartingCastMethodSpellValidationError extends BaseSpellValidationError {
+        public StartingCastMethodSpellValidationError() {
+            super(-1, null, "starting_cast_method");
+        }
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/util/SpellPartConfigUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/util/SpellPartConfigUtil.java
@@ -1,0 +1,94 @@
+package com.hollingsworth.arsnouveau.common.util;
+
+import com.hollingsworth.arsnouveau.GlyphLib;
+import net.minecraftforge.common.ForgeConfigSpec;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for code around handling spell part configuration.
+ */
+public class SpellPartConfigUtil {
+    /**
+     * Pattern describing an entry in the augment limits configuration.
+     *
+     * Expected format is "glyphtag=limit"
+     * Example: "fortune=3"
+     */
+    private static final Pattern AUGMENT_LIMITS_PATTERN = Pattern.compile("([^/=]+)=(\\p{Digit}+)");
+
+    /**
+     * Class used to encapsulate the logic around parsing and printing the augment limit configuration.
+     *
+     * Used by {@link com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart} to handle configuring augmentation
+     * limitations.
+     */
+    public static class AugmentLimits {
+        private Map<String, Integer> limits = null;
+        private ForgeConfigSpec.ConfigValue<List<? extends String>> configValue;
+
+        /** Create a new AugmentLimits from the given ConfigValue */
+        private AugmentLimits(ForgeConfigSpec.ConfigValue<List<? extends String>> configValue) {
+            this.configValue = configValue;
+        }
+
+        /** Retrieves the maximum number of times the given augment may be applied, given the configuration. */
+        public int getAugmentLimit(String augmentTag) {
+            if (limits == null) {
+                limits = parseAugmentLimits();
+            }
+            return limits.getOrDefault(augmentTag, Integer.MAX_VALUE);
+        }
+
+        /** Sets the maximum number of times the given augment may be applied and updates the configuration. */
+        public void setAugmentLimit(String augmentTag, int limit) {
+            if (limits == null) {
+                limits = parseAugmentLimits();
+            }
+            limits.put(augmentTag, limit);
+            configValue.set(writeConfig(limits));
+        }
+
+        /** Parse glyph_limits into a Map from augment glyph tags to limits. */
+        private Map<String, Integer> parseAugmentLimits() {
+            return configValue.get().stream()
+                    .map(AUGMENT_LIMITS_PATTERN::matcher)
+                    .filter(Matcher::matches)
+                    .collect(Collectors.toMap(
+                            m -> m.group(1),
+                            m -> Integer.valueOf(m.group(2))
+                    ));
+        }
+    }
+
+    /**
+     * Builds a "augment_limits" configuration item using the provided {@link ForgeConfigSpec.Builder} and returns an
+     * {@link AugmentLimits} instance to encapsulate it.
+     */
+    public static AugmentLimits buildAugmentLimitsConfig(ForgeConfigSpec.Builder builder, Map<String, Integer> defaults) {
+        ForgeConfigSpec.ConfigValue<List<? extends String>> configValue = builder
+                .comment("Limits the number of times a given augment may be applied to a given effect", "Example entry: \"" + GlyphLib.AugmentAmplifyID + "=5\"")
+                .defineList("augment_limits", writeConfig(defaults), SpellPartConfigUtil::validateAugmentLimits);
+
+        return new AugmentLimits(configValue);
+    }
+
+    /** Produces a list of tag=limit strings suitable for saving to the configuration. */
+    private static List<String> writeConfig(Map<String, Integer> augmentLimits) {
+        return augmentLimits.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue().toString())
+                .collect(Collectors.toList());
+    }
+
+    /** Ensure glyph_limits matches the expected regex pattern. */
+    private static boolean validateAugmentLimits(Object rawConfig) {
+        if (rawConfig instanceof CharSequence) {
+            return AUGMENT_LIMITS_PATTERN.matcher((CharSequence) rawConfig).matches();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/setup/Config.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/setup/Config.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.setup;
 
+import com.electronwill.nightconfig.core.InMemoryFormat;
 import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
 import net.minecraftforge.common.ForgeConfigSpec;
@@ -9,10 +10,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.loading.FMLPaths;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Mod.EventBusSubscriber
 public class Config {

--- a/src/main/resources/assets/ars_nouveau/lang/en_us.json
+++ b/src/main/resources/assets/ars_nouveau/lang/en_us.json
@@ -606,12 +606,18 @@
 	"ars_nouveau.spell.validation.exists.non_empty_spell": "The spell may not be empty.",
 	"ars_nouveau.spell.validation.exists.max_one_cast_method": "The spell has an extra form glyph: %s",
 	"ars_nouveau.spell.validation.exists.starting_cast_method": "The spell does not start with a form glyph.",
+	"ars_nouveau.spell.validation.exists.action_augmentation_policy": "%s was augmented by %s too many times.",
+	"ars_nouveau.spell.validation.exists.action_augmentation_policy.zero": "%s may not be augmented by %s.",
+	"ars_nouveau.spell.validation.exists.glyph_occurrences_policy": "%s appears too many times.",
 	"ars_nouveau.spell.validation.exists.glyph_tier": "%s is too powerful for your current spell book.",
 
 	"ars_nouveau.spell.validation.adding._comment": "__ These messages appear when attempting to add a glyph that would make a spell invalid. __",
 	"ars_nouveau.spell.validation.adding.non_empty_spell": "The spell may not be empty.",
 	"ars_nouveau.spell.validation.adding.max_one_cast_method": "The spell already has a form glyph.",
 	"ars_nouveau.spell.validation.adding.starting_cast_method": "The spell must start with a form glyph.",
+	"ars_nouveau.spell.validation.adding.action_augmentation_policy": "%s is already augmented to the limit by %s.",
+	"ars_nouveau.spell.validation.adding.action_augmentation_policy.zero": "%s may not be augmented by %s.",
+	"ars_nouveau.spell.validation.adding.glyph_occurrences_policy": "%s has appeared its maximum number of times.",
 	"ars_nouveau.spell.validation.adding.glyph_tier": "%s is too powerful for your current spell book.",
 
 	"ars_nouveau.spell.no_mana": "Not enough mana.",

--- a/src/main/resources/assets/ars_nouveau/lang/en_us.json
+++ b/src/main/resources/assets/ars_nouveau/lang/en_us.json
@@ -598,7 +598,22 @@
 	"ars_nouveau.false": "false",
 	
 	"ars_nouveau.spell_hud.crafting_mode": "Crafting Mode",
-	
+
+	"ars_nouveau.spell.validation.crafting.invalid": "There are problems with this spell.",
+	"ars_nouveau.spell.validation.crafting.invalid_glyphs": "One or more glyphs in this spell are invalid.",
+
+	"ars_nouveau.spell.validation.exists._comment": "__ These messages appear when reporting on an existing spell that is invalid. __",
+	"ars_nouveau.spell.validation.exists.non_empty_spell": "The spell may not be empty.",
+	"ars_nouveau.spell.validation.exists.max_one_cast_method": "The spell has an extra form glyph: %s",
+	"ars_nouveau.spell.validation.exists.starting_cast_method": "The spell does not start with a form glyph.",
+	"ars_nouveau.spell.validation.exists.glyph_tier": "%s is too powerful for your current spell book.",
+
+	"ars_nouveau.spell.validation.adding._comment": "__ These messages appear when attempting to add a glyph that would make a spell invalid. __",
+	"ars_nouveau.spell.validation.adding.non_empty_spell": "The spell may not be empty.",
+	"ars_nouveau.spell.validation.adding.max_one_cast_method": "The spell already has a form glyph.",
+	"ars_nouveau.spell.validation.adding.starting_cast_method": "The spell must start with a form glyph.",
+	"ars_nouveau.spell.validation.adding.glyph_tier": "%s is too powerful for your current spell book.",
+
 	"ars_nouveau.spell.no_mana": "Not enough mana.",
 	"block.ars_nouveau.potion_jar": "Potion Jar",
 	"block.ars_nouveau.potion_melder": "Potion Melder",


### PR DESCRIPTION
Added validation system for spells

Always Active:
- Maximum one cast method (Form) per spell
- Enforce configuration for the maximum number of times a given glyph map appear
- Enforce configuration for the maximum number of times an given augment may be applied to a form or effect

Casting Time Only:
- Spell must not be empty
- Spell must start with a form glyph

Bonuses:
- Fixed a number of bugs in the Spell Book UI
- Now showing Glyphs that are a higher tier than the book but were learned anyway (You still can't add them to a spell)

Implements https://github.com/baileyholl/Ars-Nouveau/issues/242