### PR TITLE
Validations: Added a validation to indicate which cast methods / effects make use of which augments

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractAugment.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractAugment.java
@@ -1,9 +1,16 @@
 package com.hollingsworth.arsnouveau.api.spell;
 
+import java.util.Set;
+
 public abstract class AbstractAugment extends AbstractSpellPart {
 
     public AbstractAugment(String tag, String description) {
         super(tag, description);
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
@@ -4,10 +4,7 @@ import com.hollingsworth.arsnouveau.api.entity.ISummon;
 import com.hollingsworth.arsnouveau.api.event.SummonEvent;
 import com.hollingsworth.arsnouveau.api.util.LootUtil;
 import com.hollingsworth.arsnouveau.common.potions.ModPotions;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDurationDown;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtract;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentFortune;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.Entity;
@@ -35,6 +32,7 @@ import net.minecraftforge.common.util.FakePlayerFactory;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 
 public abstract class AbstractEffect extends AbstractSpellPart {
@@ -180,6 +178,15 @@ public abstract class AbstractEffect extends AbstractSpellPart {
             stack.enchant(Enchantments.BLOCK_FORTUNE, getBuffCount(augments, AugmentExtract.class));
         }
     }
+
+    protected Set<AbstractAugment> POTION_AUGMENTS = augmentSetOf(
+            AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE,
+            AugmentAmplify.INSTANCE
+    );
+
+    protected Set<AbstractAugment> SUMMON_AUGMENTS = augmentSetOf(
+            AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE
+    );
 
     public ForgeConfigSpec.DoubleValue DAMAGE;
     public ForgeConfigSpec.DoubleValue AMP_VALUE;

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
@@ -14,10 +14,7 @@ import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -80,6 +77,20 @@ public abstract class AbstractSpellPart implements ISpellTier, Comparable<Abstra
 
     public int getAmplificationBonus(List<AbstractAugment> augmentTypes){
         return getBuffCount(augmentTypes, AugmentAmplify.class) - getBuffCount(augmentTypes, AugmentDampen.class);
+    }
+
+    /**
+     * Returns the set of augments that this spell part can be enhanced by.
+     *
+     * @see AbstractSpellPart#augmentSetOf(AbstractAugment...) for easy syntax to make the Set.
+     */
+    public abstract Set<AbstractAugment> getCompatibleAugments();
+
+    /**
+     * Syntax support to easily make a set for {@link AbstractSpellPart#getCompatibleAugments()}
+     */
+    protected Set<AbstractAugment> augmentSetOf(AbstractAugment... augments) {
+        return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(augments)));
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/command/DataDumpCommand.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/command/DataDumpCommand.java
@@ -1,0 +1,105 @@
+package com.hollingsworth.arsnouveau.common.command;
+
+import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
+import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
+import com.hollingsworth.arsnouveau.api.spell.AbstractCastMethod;
+import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.util.Tuple;
+import net.minecraft.util.text.StringTextComponent;
+import org.apache.commons.io.output.FileWriterWithEncoding;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class DataDumpCommand {
+    public static final Path PATH_AUGMENT_COMPATIBILITY = Paths.get("ars_nouveau", "augment_compatibility.csv");
+
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        dispatcher.register(Commands.literal("ars-data")
+                .requires(sender -> sender.hasPermission(2)) // Op required
+                .then(Commands.literal("dump")
+                .then(Commands.literal("augment-compatibility-csv")
+                .executes(DataDumpCommand::dumpAugmentCompat)))
+        );
+    }
+
+    /**
+     * Creates a CSV file at {@link DataDumpCommand#PATH_AUGMENT_COMPATIBILITY} all augment compatibility information
+     */
+    public static int dumpAugmentCompat(CommandContext<CommandSource> context) {
+        Map<String, AbstractSpellPart> spells = ArsNouveauAPI.getInstance().getSpell_map();
+
+        // Collect the Augments
+        List<AbstractAugment> augments = spells.values().stream()
+                .filter(p -> p instanceof AbstractAugment)
+                .map(p -> (AbstractAugment) p)
+                .sorted(Comparator.comparing(a -> a.tag))
+                .collect(Collectors.toList());
+
+        // Collect the augment compatibilities
+        List<Tuple<AbstractSpellPart, Set<AbstractAugment>>> augmentCompat = spells.values().stream()
+                .filter(part -> part instanceof AbstractCastMethod)
+                .map(part -> new Tuple<>(part, part.getCompatibleAugments()))
+                .sorted(Comparator.comparing(t -> t.getA().tag))
+                .collect(Collectors.toList());
+        // Technically can be done in one sort, but writing a comparator based on type is ugly.
+        augmentCompat.addAll(spells.values().stream()
+                .filter(part -> part instanceof AbstractEffect)
+                .map(part -> new Tuple<>(part, part.getCompatibleAugments()))
+                .sorted(Comparator.comparing(t -> t.getA().tag))
+                .collect(Collectors.toList()));
+
+        // Write the file
+        File file = PATH_AUGMENT_COMPATIBILITY.toFile();
+        try {
+            Files.createDirectories(PATH_AUGMENT_COMPATIBILITY.getParent());
+            PrintWriter w = new PrintWriter(new FileWriterWithEncoding(file, "UTF-8", false));
+
+            // Header Line
+            w.println("glyph, " + augments.stream().map(a -> a.tag).collect(Collectors.joining(", ")));
+
+            // Rows
+            for (Tuple<AbstractSpellPart, Set<AbstractAugment>> row : augmentCompat) {
+                AbstractSpellPart part = row.getA();
+                Set<AbstractAugment> compatibleAugments = row.getB();
+
+                w.print(part.tag + ", ");
+
+                // Columns
+                w.print(augments.stream()
+                        .map(a -> compatibleAugments.contains(a) ? "T" : "F")
+                        .collect(Collectors.joining(", ")));
+                w.println();
+            }
+            w.close();
+        } catch (IOException ex) {
+            LogManager.getLogger(ArsNouveau.MODID).error("Unable to dump augment compatibility chart", ex);
+            context.getSource().sendFailure(new StringTextComponent("Error when trying to produce the data dump.  Check the logs."));
+
+            // This is somewhat expected, just fail the command.  Logging took care of reporting.
+            return 0;
+        } catch (Exception ex) {
+            LogManager.getLogger(ArsNouveau.MODID).error("Exception caught when trying to dump data", ex);
+            context.getSource().sendFailure(new StringTextComponent("Error when trying to produce the data dump.  Check the logs."));
+
+            // We really didn't expect this.  Re-throw.
+            throw ex;
+        }
+
+        context.getSource().sendSuccess(new StringTextComponent("Dumped data to " + file), true);
+        return 1;
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
@@ -5,6 +5,7 @@ import com.hollingsworth.arsnouveau.api.event.DispelEvent;
 import com.hollingsworth.arsnouveau.client.ClientInfo;
 import com.hollingsworth.arsnouveau.client.particle.ParticleUtil;
 import com.hollingsworth.arsnouveau.common.block.LavaLily;
+import com.hollingsworth.arsnouveau.common.command.DataDumpCommand;
 import com.hollingsworth.arsnouveau.common.command.ResetCommand;
 import com.hollingsworth.arsnouveau.common.items.VoidJar;
 import com.hollingsworth.arsnouveau.common.potions.ModPotions;
@@ -157,6 +158,7 @@ public class EventHandler {
     @SubscribeEvent
     public static void commandRegister(RegisterCommandsEvent event){
         ResetCommand.register(event.getDispatcher());
+        DataDumpCommand.register(event.getDispatcher());
     }
 
     private EventHandler(){}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectAquatic.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectAquatic.java
@@ -14,7 +14,10 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class EffectAquatic extends AbstractEffect {
 
@@ -51,6 +54,11 @@ public class EffectAquatic extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.COD;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return POTION_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBlink.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBlink.java
@@ -8,6 +8,8 @@ import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.common.items.WarpScroll;
 import com.hollingsworth.arsnouveau.common.network.Networking;
 import com.hollingsworth.arsnouveau.common.network.PacketWarpPosition;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.setup.ItemsRegistry;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -27,6 +29,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectBlink extends AbstractEffect {
     public static EffectBlink INSTANCE = new EffectBlink();
@@ -161,6 +164,11 @@ public class EffectBlink extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.ENDER_PEARL;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBreak.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBreak.java
@@ -6,10 +6,7 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.BlockUtil;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtract;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentFortune;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.material.Material;
 import net.minecraft.enchantment.Enchantment;
@@ -28,6 +25,7 @@ import net.minecraft.world.server.ServerWorld;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.hollingsworth.arsnouveau.api.util.BlockUtil.destroyBlockSafely;
 
@@ -112,6 +110,17 @@ public class EffectBreak extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.IRON_PICKAXE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentPierce.INSTANCE,
+                AugmentAOE.INSTANCE,
+                AugmentExtract.INSTANCE,
+                AugmentFortune.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectColdSnap.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectColdSnap.java
@@ -6,7 +6,7 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.client.particle.ParticleUtil;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -22,6 +22,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectColdSnap extends AbstractEffect {
 
@@ -86,6 +87,16 @@ public class EffectColdSnap extends AbstractEffect {
     @Override
     public int getManaCost() {
         return 30;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE,
+                AugmentAOE.INSTANCE,
+                AugmentFortune.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectConjureWater.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectConjureWater.java
@@ -23,6 +23,7 @@ import net.minecraft.world.server.ServerWorld;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectConjureWater extends AbstractEffect {
 
@@ -62,6 +63,11 @@ public class EffectConjureWater extends AbstractEffect {
     @Override
     public int getManaCost() {
         return 80;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAOE.INSTANCE, AugmentPierce.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCraft.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCraft.java
@@ -19,6 +19,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectCraft extends AbstractEffect {
 
@@ -64,6 +65,11 @@ public class EffectCraft extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.CRAFTING_TABLE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCrush.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCrush.java
@@ -5,8 +5,7 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.LivingEntity;
@@ -22,6 +21,7 @@ import net.minecraftforge.common.Tags;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectCrush extends AbstractEffect {
 
@@ -57,6 +57,15 @@ public class EffectCrush extends AbstractEffect {
         super.buildConfig(builder);
         addDamageConfig(builder, 3.0);
         addAmpConfig(builder, 1.0);
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentAOE.INSTANCE, AugmentPierce.INSTANCE,
+                AugmentFortune.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCut.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCut.java
@@ -6,9 +6,7 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentFortune;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.ItemEntity;
@@ -28,6 +26,7 @@ import net.minecraftforge.common.IForgeShearable;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectCut extends AbstractEffect {
 
@@ -79,6 +78,14 @@ public class EffectCut extends AbstractEffect {
         super.buildConfig(builder);
         addDamageConfig(builder, 1.0);
         addAmpConfig(builder, 1.0);
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentExtract.INSTANCE, AugmentFortune.INSTANCE,
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectDelay.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectDelay.java
@@ -16,6 +16,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectDelay extends AbstractEffect {
     public static EffectDelay INSTANCE = new EffectDelay();
@@ -47,6 +48,11 @@ public class EffectDelay extends AbstractEffect {
     @Override
     public int getManaCost() {
         return 0;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentExtendTime.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectDispel.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectDispel.java
@@ -20,6 +20,7 @@ import net.minecraftforge.common.MinecraftForge;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public class EffectDispel extends AbstractEffect {
     public static EffectDispel INSTANCE = new EffectDispel();
@@ -65,6 +66,12 @@ public class EffectDispel extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.MILK_BUCKET;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        // Augments were sent with the DispelEvent, but there's no use of its augments field.
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectEnderChest.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectEnderChest.java
@@ -19,6 +19,7 @@ import net.minecraftforge.common.util.FakePlayer;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectEnderChest extends AbstractEffect {
     public static EffectEnderChest INSTANCE = new EffectEnderChest();
@@ -38,6 +39,11 @@ public class EffectEnderChest extends AbstractEffect {
             }, CONTAINER_NAME));
         }
 
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectExchange.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectExchange.java
@@ -5,8 +5,7 @@ import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.spell.*;
 import com.hollingsworth.arsnouveau.api.util.LootUtil;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import com.hollingsworth.arsnouveau.setup.BlockRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -31,6 +30,7 @@ import net.minecraftforge.items.IItemHandler;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static com.hollingsworth.arsnouveau.api.util.BlockUtil.destroyBlockSafelyWithoutSound;
 
@@ -163,6 +163,15 @@ public class EffectExchange extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.TWO;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentPierce.INSTANCE,
+                AugmentAOE.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectExplosion.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectExplosion.java
@@ -26,6 +26,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectExplosion extends AbstractEffect {
     public static EffectExplosion INSTANCE = new EffectExplosion();
@@ -103,6 +104,15 @@ public class EffectExplosion extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.TWO;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentAOE.INSTANCE,
+                AugmentExtract.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFangs.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFangs.java
@@ -5,7 +5,7 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.common.entity.EntityEvokerFangs;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAccelerate;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -23,6 +23,7 @@ import net.minecraftforge.common.util.FakePlayerFactory;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectFangs extends AbstractEffect {
     public static EffectFangs INSTANCE = new EffectFangs();
@@ -123,6 +124,15 @@ public class EffectFangs extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.THREE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE,
+                AugmentAccelerate.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFell.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFell.java
@@ -114,6 +114,15 @@ public class EffectFell extends AbstractEffect {
     }
 
     @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAOE.INSTANCE,
+                AugmentExtract.INSTANCE,
+                AugmentFortune.INSTANCE
+        );
+    }
+
+    @Override
     public String getBookDescription() {
         return "Harvests entire trees, mushrooms, cactus, and other vegetation. Can be amplified with Amplify to break materials of higher hardness. AOE will increase the number of blocks that may be broken at one time.";
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFlare.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFlare.java
@@ -6,7 +6,7 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.client.particle.ParticleUtil;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -21,6 +21,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectFlare extends AbstractEffect {
     public static EffectFlare INSTANCE = new EffectFlare();
@@ -69,6 +70,16 @@ public class EffectFlare extends AbstractEffect {
     @Override
     public int getManaCost() {
         return 40;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE,
+                AugmentAOE.INSTANCE,
+                AugmentFortune.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFreeze.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFreeze.java
@@ -20,6 +20,7 @@ import net.minecraftforge.common.ForgeMod;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectFreeze extends AbstractEffect {
     public static EffectFreeze INSTANCE = new EffectFreeze();
@@ -91,6 +92,11 @@ public class EffectFreeze extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.SNOW_BLOCK;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return POTION_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGlide.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGlide.java
@@ -5,6 +5,8 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.common.potions.ModPotions;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDurationDown;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
@@ -15,6 +17,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectGlide extends AbstractEffect {
 
@@ -47,5 +50,11 @@ public class EffectGlide extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.ELYTRA;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        // ModPotions.GLIDE_EFFECT does not respond to amplification
+        return augmentSetOf(AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE);
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGravity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGravity.java
@@ -7,6 +7,8 @@ import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.BlockUtil;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -21,6 +23,7 @@ import net.minecraft.world.server.ServerWorld;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectGravity extends AbstractEffect {
     public static EffectGravity INSTANCE = new EffectGravity();
@@ -65,6 +68,15 @@ public class EffectGravity extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.TWO;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentAOE.INSTANCE,
+                AugmentPierce.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGrow.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGrow.java
@@ -22,6 +22,7 @@ import net.minecraftforge.common.util.FakePlayerFactory;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectGrow  extends AbstractEffect {
     public static EffectGrow INSTANCE = new EffectGrow();
@@ -66,6 +67,11 @@ public class EffectGrow  extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.TWO;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAOE.INSTANCE, AugmentPierce.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHarm.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHarm.java
@@ -4,7 +4,7 @@ import com.hollingsworth.arsnouveau.GlyphLib;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -19,6 +19,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectHarm extends AbstractEffect {
     public static EffectHarm INSTANCE = new EffectHarm();
@@ -72,6 +73,15 @@ public class EffectHarm extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.IRON_SWORD;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE,
+                AugmentFortune.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHarvest.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHarvest.java
@@ -27,6 +27,7 @@ import net.minecraft.world.server.ServerWorld;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectHarvest extends AbstractEffect {
     public static EffectHarvest INSTANCE = new EffectHarvest();
@@ -103,6 +104,11 @@ public class EffectHarvest extends AbstractEffect {
     @Override
     public int getManaCost() {
         return 10;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAOE.INSTANCE, AugmentPierce.INSTANCE, AugmentFortune.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHaste.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHaste.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectHaste extends AbstractEffect {
     public static EffectHaste INSTANCE = new EffectHaste();
@@ -62,6 +63,11 @@ public class EffectHaste extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.ONE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return POTION_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHeal.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHeal.java
@@ -4,8 +4,7 @@ import com.hollingsworth.arsnouveau.GlyphLib;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
@@ -17,6 +16,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectHeal extends AbstractEffect {
     public static EffectHeal INSTANCE = new EffectHeal();
@@ -71,6 +71,15 @@ public class EffectHeal extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.GLISTERING_MELON_SLICE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE,
+                AugmentFortune.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHex.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectHex.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectHex extends AbstractEffect {
     public static EffectHex INSTANCE = new EffectHex();
@@ -37,6 +38,11 @@ public class EffectHex extends AbstractEffect {
         super.buildConfig(builder);
         addPotionConfig(builder, 30);
         addExtendTimeConfig(builder, 8);
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return POTION_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectIgnite.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectIgnite.java
@@ -26,6 +26,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectIgnite  extends AbstractEffect {
     public static EffectIgnite INSTANCE = new EffectIgnite();
@@ -82,6 +83,11 @@ public class EffectIgnite  extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.FLINT_AND_STEEL;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentExtendTime.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectIntangible.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectIntangible.java
@@ -7,8 +7,7 @@ import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.BlockUtil;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.block.tile.IntangibleAirTile;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
-import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
+import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import com.hollingsworth.arsnouveau.setup.BlockRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -25,6 +24,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectIntangible extends AbstractEffect {
     public static EffectIntangible INSTANCE = new EffectIntangible();
@@ -75,6 +75,16 @@ public class EffectIntangible extends AbstractEffect {
     @Override
     public int getManaCost() {
         return 30;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentExtendTime.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentPierce.INSTANCE,
+                AugmentAOE.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectInteract.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectInteract.java
@@ -29,6 +29,7 @@ import net.minecraftforge.common.util.FakePlayerFactory;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class EffectInteract extends AbstractEffect {
     public static EffectInteract INSTANCE = new EffectInteract();
@@ -118,6 +119,11 @@ public class EffectInteract extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.LEVER;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectInvisibility.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectInvisibility.java
@@ -5,6 +5,8 @@ import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDurationDown;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.potion.Effects;
@@ -15,6 +17,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectInvisibility extends AbstractEffect {
     public static EffectInvisibility INSTANCE = new EffectInvisibility();
@@ -51,6 +54,12 @@ public class EffectInvisibility extends AbstractEffect {
     @Override
     public int getManaCost() {
         return 30;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        // Augmentation has no effect
+        return augmentSetOf(AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectKnockback.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectKnockback.java
@@ -4,6 +4,8 @@ import com.hollingsworth.arsnouveau.GlyphLib;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
@@ -15,6 +17,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectKnockback extends AbstractEffect {
     public static EffectKnockback INSTANCE = new EffectKnockback();
@@ -63,6 +66,11 @@ public class EffectKnockback extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.PISTON;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectLaunch.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectLaunch.java
@@ -4,6 +4,8 @@ import com.hollingsworth.arsnouveau.GlyphLib;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -15,6 +17,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectLaunch extends AbstractEffect {
     public static EffectLaunch INSTANCE = new EffectLaunch();
@@ -59,6 +62,11 @@ public class EffectLaunch extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.SLIME_BALL;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectLeap.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectLeap.java
@@ -4,6 +4,8 @@ import com.hollingsworth.arsnouveau.GlyphLib;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.setup.ItemsRegistry;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -13,6 +15,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeConfigSpec;
 
 import java.util.List;
+import java.util.Set;
 
 public class EffectLeap extends AbstractEffect {
     public static EffectLeap INSTANCE = new EffectLeap();
@@ -44,6 +47,11 @@ public class EffectLeap extends AbstractEffect {
     @Override
     public boolean wouldSucceed(RayTraceResult rayTraceResult, World world, LivingEntity shooter, List<AbstractAugment> augments) {
         return livingEntityHitSuccess(rayTraceResult);
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectLight.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectLight.java
@@ -8,6 +8,8 @@ import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.BlockUtil;
 import com.hollingsworth.arsnouveau.common.block.SconceBlock;
 import com.hollingsworth.arsnouveau.common.block.tile.LightTile;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.setup.BlockRegistry;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.LivingEntity;
@@ -22,7 +24,10 @@ import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class EffectLight extends AbstractEffect {
     public static EffectLight INSTANCE = new EffectLight();
@@ -78,6 +83,12 @@ public class EffectLight extends AbstractEffect {
     @Nullable
     @Override
     public Item getCraftingReagent(){return Items.LANTERN;}
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        // Potion augments includes amp/dampen which apply when creating light sources.
+        return POTION_AUGMENTS;
+    }
 
     @Override
     public String getBookDescription() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectLightning.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectLightning.java
@@ -6,6 +6,10 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.common.entity.LightningEntity;
 import com.hollingsworth.arsnouveau.common.entity.ModEntities;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDurationDown;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.Item;
@@ -17,6 +21,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectLightning extends AbstractEffect {
     public static EffectLightning INSTANCE = new EffectLightning();
@@ -61,6 +66,14 @@ public class EffectLightning extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.HEART_OF_THE_SEA;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectPhantomBlock.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectPhantomBlock.java
@@ -21,6 +21,7 @@ import net.minecraft.world.server.ServerWorld;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectPhantomBlock extends AbstractEffect {
     public static EffectPhantomBlock INSTANCE = new EffectPhantomBlock();
@@ -53,6 +54,11 @@ public class EffectPhantomBlock extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.GLASS;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAOE.INSTANCE, AugmentPierce.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectPickup.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectPickup.java
@@ -20,6 +20,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectPickup extends AbstractEffect {
     public static EffectPickup INSTANCE = new EffectPickup();
@@ -56,6 +57,11 @@ public class EffectPickup extends AbstractEffect {
     @Override
     public boolean wouldSucceed(RayTraceResult rayTraceResult, World world, LivingEntity shooter, List<AbstractAugment> augments) {
         return true;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAOE.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectPlaceBlock.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectPlaceBlock.java
@@ -27,6 +27,7 @@ import net.minecraftforge.common.util.FakePlayer;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectPlaceBlock extends AbstractEffect {
     public static EffectPlaceBlock INSTANCE = new EffectPlaceBlock();
@@ -103,6 +104,11 @@ public class EffectPlaceBlock extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.DISPENSER;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAOE.INSTANCE, AugmentPierce.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectPull.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectPull.java
@@ -4,6 +4,8 @@ import com.hollingsworth.arsnouveau.GlyphLib;
 import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
@@ -16,6 +18,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectPull extends AbstractEffect {
     public static EffectPull INSTANCE = new EffectPull();
@@ -60,6 +63,11 @@ public class EffectPull extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.FISHING_ROD;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectRedstone.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectRedstone.java
@@ -6,6 +6,8 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.BlockUtil;
 import com.hollingsworth.arsnouveau.common.block.RedstoneAir;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
 import com.hollingsworth.arsnouveau.setup.BlockRegistry;
 import net.minecraft.block.BlockState;
@@ -21,6 +23,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectRedstone extends AbstractEffect {
     public static EffectRedstone INSTANCE = new EffectRedstone();
@@ -68,6 +71,11 @@ public class EffectRedstone extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.REDSTONE_BLOCK;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE, AugmentExtendTime.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectShield.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectShield.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectShield extends AbstractEffect {
     public static EffectShield INSTANCE = new EffectShield();
@@ -56,6 +57,11 @@ public class EffectShield extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.TWO;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return POTION_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSlowfall.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSlowfall.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectSlowfall extends AbstractEffect {
     public static EffectSlowfall INSTANCE = new EffectSlowfall();
@@ -56,6 +57,11 @@ public class EffectSlowfall extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.ONE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return POTION_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSmelt.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSmelt.java
@@ -7,6 +7,8 @@ import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.util.BlockUtil;
 import com.hollingsworth.arsnouveau.api.util.SpellUtil;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAOE;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentAmplify;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentPierce;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.LivingEntity;
@@ -27,6 +29,7 @@ import net.minecraft.world.server.ServerWorld;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public class EffectSmelt extends AbstractEffect {
     public static EffectSmelt INSTANCE = new EffectSmelt();
@@ -101,6 +104,14 @@ public class EffectSmelt extends AbstractEffect {
     @Override
     public boolean wouldSucceed(RayTraceResult rayTraceResult, World world, LivingEntity shooter, List<AbstractAugment> augments) {
         return rayTraceResult instanceof BlockRayTraceResult;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(
+                AugmentAmplify.INSTANCE, AugmentDampen.INSTANCE,
+                AugmentAOE.INSTANCE, AugmentPierce.INSTANCE
+        );
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSnare.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSnare.java
@@ -17,6 +17,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeConfigSpec;
 
 import java.util.List;
+import java.util.Set;
 
 public class EffectSnare extends AbstractEffect {
     public static EffectSnare INSTANCE = new EffectSnare();
@@ -47,6 +48,11 @@ public class EffectSnare extends AbstractEffect {
     @Override
     public boolean wouldSucceed(RayTraceResult rayTraceResult, World world, LivingEntity shooter, List<AbstractAugment> augments) {
         return livingEntityHitSuccess(rayTraceResult);
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentExtendTime.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectStrength.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectStrength.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectStrength extends AbstractEffect {
     public static EffectStrength INSTANCE = new EffectStrength();
@@ -51,6 +52,11 @@ public class EffectStrength extends AbstractEffect {
     @Override
     public Item getCraftingReagent() {
         return Items.BLAZE_POWDER;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return POTION_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonDecoy.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonDecoy.java
@@ -5,6 +5,8 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
 import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.common.entity.EntityDummy;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.item.Item;
@@ -16,6 +18,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectSummonDecoy extends AbstractEffect {
     public static EffectSummonDecoy INSTANCE = new EffectSummonDecoy();
@@ -57,6 +60,12 @@ public class EffectSummonDecoy extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.THREE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        // SummonEvent captures augments, but no uses of that field were found
+        return SUMMON_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonSteed.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonSteed.java
@@ -6,6 +6,8 @@ import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.common.entity.ModEntities;
 import com.hollingsworth.arsnouveau.common.entity.SummonHorse;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDurationDown;
+import com.hollingsworth.arsnouveau.common.spell.augment.AugmentExtendTime;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
@@ -19,6 +21,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectSummonSteed extends AbstractEffect {
     public static EffectSummonSteed INSTANCE = new EffectSummonSteed();
@@ -66,6 +69,10 @@ public class EffectSummonSteed extends AbstractEffect {
         return Tier.ONE;
     }
 
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return SUMMON_AUGMENTS;
+    }
 
     @Override
     public String getBookDescription() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonVex.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonVex.java
@@ -22,6 +22,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectSummonVex extends AbstractEffect {
     public static EffectSummonVex INSTANCE = new EffectSummonVex();
@@ -80,6 +81,11 @@ public class EffectSummonVex extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.THREE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return SUMMON_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonWolves.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonWolves.java
@@ -17,6 +17,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectSummonWolves extends AbstractEffect {
     public static EffectSummonWolves INSTANCE = new EffectSummonWolves();
@@ -57,6 +58,11 @@ public class EffectSummonWolves extends AbstractEffect {
         return 100;
     }
 
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        // SummonEvent captures augments, but no uses of that field were found
+        return SUMMON_AUGMENTS;
+    }
 
     @Override
     public String getBookDescription() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWither.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWither.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class EffectWither extends AbstractEffect {
     public static EffectWither INSTANCE = new EffectWither();
@@ -52,6 +53,11 @@ public class EffectWither extends AbstractEffect {
     @Override
     public Tier getTier() {
         return Tier.THREE;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return POTION_AUGMENTS;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodBeam.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodBeam.java
@@ -15,6 +15,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class MethodBeam extends AbstractCastMethod {
     public MethodBeam() {
@@ -78,5 +79,10 @@ public class MethodBeam extends AbstractCastMethod {
     @Override
     public int getManaCost() {
         return 0;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodProjectile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodProjectile.java
@@ -26,6 +26,7 @@ import net.minecraft.world.World;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class MethodProjectile extends AbstractCastMethod {
     public static MethodProjectile INSTANCE = new MethodProjectile();
@@ -142,6 +143,11 @@ public class MethodProjectile extends AbstractCastMethod {
     @Override
     public boolean wouldCastOnEntitySuccessfully(@Nullable ItemStack stack, LivingEntity caster, LivingEntity target, Hand hand, List<AbstractAugment> augments) {
         return true;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf(AugmentPierce.INSTANCE, AugmentSplit.INSTANCE, AugmentAccelerate.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodRune.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodRune.java
@@ -21,6 +21,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class MethodRune extends AbstractCastMethod {
     public static MethodRune INSTANCE = new MethodRune();
@@ -102,6 +103,11 @@ public class MethodRune extends AbstractCastMethod {
     @Override
     public int getManaCost() {
         return 30;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodSelf.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodSelf.java
@@ -18,6 +18,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class MethodSelf extends AbstractCastMethod {
     public static MethodSelf INSTANCE = new MethodSelf();
@@ -80,6 +81,11 @@ public class MethodSelf extends AbstractCastMethod {
     @Override
     public int getManaCost() {
         return 10;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodTouch.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodTouch.java
@@ -18,6 +18,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class MethodTouch extends AbstractCastMethod {
     public static MethodTouch INSTANCE = new MethodTouch();
@@ -80,6 +81,11 @@ public class MethodTouch extends AbstractCastMethod {
     @Override
     public boolean wouldCastOnEntitySuccessfully(@Nullable ItemStack stack, LivingEntity caster, LivingEntity target, Hand hand, List<AbstractAugment> augments) {
         return resolver.wouldAllEffectsDoWork(new EntityRayTraceResult(target), caster.getCommandSenderWorld(), caster, augments);
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodUnderfoot.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodUnderfoot.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 public class MethodUnderfoot extends AbstractCastMethod {
     public static MethodUnderfoot INSTANCE = new MethodUnderfoot();
@@ -72,6 +73,11 @@ public class MethodUnderfoot extends AbstractCastMethod {
     @Override
     public int getManaCost() {
         return 5;
+    }
+
+    @Override
+    public Set<AbstractAugment> getCompatibleAugments() {
+        return augmentSetOf();
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/AugmentCompatibilityValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/AugmentCompatibilityValidator.java
@@ -1,0 +1,40 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Spell validation that checks a cast method or effect's augment compatibility.
+ *
+ * @see AbstractSpellPart#getCompatibleAugments()
+ */
+public class AugmentCompatibilityValidator extends SpellPhraseValidator {
+    private static org.apache.logging.log4j.Logger logger = org.apache.logging.log4j.LogManager.getLogger(ArsNouveau.MODID + ".AugmentCompatibilityValidator");
+
+    @Override
+    protected void validatePhrase(SpellPhrase phrase, List<SpellValidationError> validationErrors) {
+        AbstractSpellPart action = phrase.getAction();
+
+        if (action != null) {
+            phrase.getAugmentPositionMap().values().stream()
+                    .flatMap(Collection::stream)
+                    .forEach(aug -> {
+                        if (!action.getCompatibleAugments().contains(aug.spellPart)) {
+                            validationErrors.add(new AugmentCompatibilitySpellValidationError(aug.position, action, aug.spellPart));
+                        }
+                    });
+        }
+    }
+
+    private static class AugmentCompatibilitySpellValidationError extends BaseSpellValidationError {
+        public AugmentCompatibilitySpellValidationError(int position, AbstractSpellPart spellPart, AbstractAugment augment) {
+            super(position, spellPart, "augment_compatibility", spellPart, augment);
+        }
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/GlyphOccurrencesPolicyValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/GlyphOccurrencesPolicyValidator.java
@@ -2,7 +2,6 @@ package com.hollingsworth.arsnouveau.common.spell.validation;
 
 import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
 import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
-import com.hollingsworth.arsnouveau.setup.Config;
 
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StandardSpellValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/StandardSpellValidator.java
@@ -21,6 +21,7 @@ public class StandardSpellValidator implements ISpellValidator {
     private static final ISpellValidator REQUIRE_CAST_METHOD_START = new StartingCastMethodSpellValidator();
     private static final ISpellValidator GLYPH_OCCURRENCES_POLICY = new GlyphOccurrencesPolicyValidator();
     private static final ISpellValidator EFFECT_AUGMENTATION_POLICY = new ActionAugmentationPolicyValidator();
+    private static final ISpellValidator AUGMENT_COMPATIBILITY = new AugmentCompatibilityValidator();
 
     private final ISpellValidator combinedValidator;
 
@@ -38,6 +39,12 @@ public class StandardSpellValidator implements ISpellValidator {
         validators.add(MAX_ONE_CAST_METHOD);
         validators.add(GLYPH_OCCURRENCES_POLICY);
         validators.add(EFFECT_AUGMENTATION_POLICY);
+
+        // Validators only applicable at crafting time
+        if (!enforceCastTimeValidations) {
+            // Not enforcing this at cast time so we don't break existing spells with ineffective augments
+            validators.add(AUGMENT_COMPATIBILITY);
+        }
 
         // Validators only applicable at casting time
         if (enforceCastTimeValidations) {

--- a/src/main/resources/assets/ars_nouveau/lang/en_us.json
+++ b/src/main/resources/assets/ars_nouveau/lang/en_us.json
@@ -609,6 +609,7 @@
 	"ars_nouveau.spell.validation.exists.action_augmentation_policy": "%s was augmented by %s too many times.",
 	"ars_nouveau.spell.validation.exists.action_augmentation_policy.zero": "%s may not be augmented by %s.",
 	"ars_nouveau.spell.validation.exists.glyph_occurrences_policy": "%s appears too many times.",
+	"ars_nouveau.spell.validation.exists.augment_compatibility": "%s cannot be augmented by %s",
 	"ars_nouveau.spell.validation.exists.glyph_tier": "%s is too powerful for your current spell book.",
 
 	"ars_nouveau.spell.validation.adding._comment": "__ These messages appear when attempting to add a glyph that would make a spell invalid. __",
@@ -618,6 +619,7 @@
 	"ars_nouveau.spell.validation.adding.action_augmentation_policy": "%s is already augmented to the limit by %s.",
 	"ars_nouveau.spell.validation.adding.action_augmentation_policy.zero": "%s may not be augmented by %s.",
 	"ars_nouveau.spell.validation.adding.glyph_occurrences_policy": "%s has appeared its maximum number of times.",
+	"ars_nouveau.spell.validation.adding.augment_compatibility": "%s cannot be augmented by %s",
 	"ars_nouveau.spell.validation.adding.glyph_tier": "%s is too powerful for your current spell book.",
 
 	"ars_nouveau.spell.no_mana": "Not enough mana.",


### PR DESCRIPTION
 * Added a new validator that applies only at crafting time to block creation of spells with ineffective augments
   * The validator is not active at cast time so as not to break existing spells.
 * Updated every cast method and effect to declare which augments it makes use of
 * Added a command /ars-data dump augment-compatibility-csv to write out the compatibility table
   * The file will be located from the minecraft instance directory at `ars_nouveau/augment_compatibility.csv`