### PR TITLE
Reduced spam around spell casting and inscribing spells onto items

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/item/ICasterTool.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/item/ICasterTool.java
@@ -51,11 +51,11 @@ public interface ICasterTool extends IScribeable, IDisplayMana {
     }
 
     default void sendSetMessage(PlayerEntity player){
-        PortUtil.sendMessage(player, new TranslationTextComponent("ars_nouveau.set_spell"));
+        PortUtil.sendMessageNoSpam(player, new TranslationTextComponent("ars_nouveau.set_spell"));
     }
 
     default void sendInvalidMessage(PlayerEntity player){
-        PortUtil.sendMessage(player, new TranslationTextComponent("ars_nouveau.invalid_spell"));
+        PortUtil.sendMessageNoSpam(player, new TranslationTextComponent("ars_nouveau.invalid_spell"));
     }
 
     default ISpellCaster getSpellCaster(ItemStack stack){

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/SpellResolver.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/SpellResolver.java
@@ -85,7 +85,7 @@ public class SpellResolver {
             // Validation failed, explain why if applicable
             if (!silent && !entity.getCommandSenderWorld().isClientSide) {
                 // Sending only the first error to avoid spam
-                PortUtil.sendMessage(entity, validationErrors.get(0).makeTextComponentExisting());
+                PortUtil.sendMessageNoSpam(entity, validationErrors.get(0).makeTextComponentExisting());
             }
             return false;
         }
@@ -97,7 +97,7 @@ public class SpellResolver {
         ManaCapability.getMana(entity).ifPresent(mana -> {
             canCast.set(totalCost <= mana.getCurrentMana() || (entity instanceof PlayerEntity &&  ((PlayerEntity) entity).isCreative()));
             if(!canCast.get() && !entity.getCommandSenderWorld().isClientSide && !silent)
-                PortUtil.sendMessage(entity,new TranslationTextComponent("ars_nouveau.spell.no_mana"));
+                PortUtil.sendMessageNoSpam(entity,new TranslationTextComponent("ars_nouveau.spell.no_mana"));
         });
         return canCast.get();
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/EnchantersSword.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/EnchantersSword.java
@@ -60,7 +60,7 @@ public class EnchantersSword extends SwordItem implements ICasterTool, IAnimatab
 
     @Override
     public void sendInvalidMessage(PlayerEntity player) {
-        PortUtil.sendMessage(player, new TranslationTextComponent("ars_nouveau.sword.invalid"));
+        PortUtil.sendMessageNoSpam(player, new TranslationTextComponent("ars_nouveau.sword.invalid"));
     }
 
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellBow.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellBow.java
@@ -237,7 +237,7 @@ public class SpellBow extends BowItem implements IAnimatable, ICasterTool {
 
     @Override
     public void sendInvalidMessage(PlayerEntity player) {
-        PortUtil.sendMessage(player, new TranslationTextComponent("ars_nouveau.bow.invalid"));
+        PortUtil.sendMessageNoSpam(player, new TranslationTextComponent("ars_nouveau.bow.invalid"));
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/Wand.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/Wand.java
@@ -73,7 +73,7 @@ public class Wand extends ModItem  implements IAnimatable, ICasterTool {
         }
 
         if(caster.getSpell() == null) {
-            playerIn.sendMessage(new TranslationTextComponent("ars_nouveau.wand.spell_invalid"), Util.NIL_UUID);
+            PortUtil.sendMessageNoSpam(playerIn, new TranslationTextComponent("ars_nouveau.wand.spell_invalid"));
             return new ActionResult<>(ActionResultType.CONSUME, stack);
         }
         SpellResolver resolver = new SpellResolver(caster.getSpell().recipe, new SpellContext(caster.getSpell(), playerIn));
@@ -113,7 +113,7 @@ public class Wand extends ModItem  implements IAnimatable, ICasterTool {
 
     @Override
     public void sendInvalidMessage(PlayerEntity player) {
-        PortUtil.sendMessage(player, new TranslationTextComponent("ars_nouveau.wand.invalid"));
+        PortUtil.sendMessageNoSpam(player, new TranslationTextComponent("ars_nouveau.wand.invalid"));
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/network/Networking.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/network/Networking.java
@@ -2,14 +2,23 @@ package com.hollingsworth.arsnouveau.common.network;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.common.thread.EffectiveSide;
+import net.minecraftforge.fml.network.NetworkDirection;
 import net.minecraftforge.fml.network.NetworkRegistry;
 import net.minecraftforge.fml.network.PacketDistributor;
 import net.minecraftforge.fml.network.simple.SimpleChannel;
+import org.jline.utils.Log;
+
+import java.util.Optional;
 
 public class Networking {
     public static SimpleChannel INSTANCE;
@@ -101,6 +110,13 @@ public class Networking {
                 PacketGetPersistentData::toBytes,
                 PacketGetPersistentData::new,
                 PacketGetPersistentData::handle);
+
+        INSTANCE.registerMessage(nextID(),
+                PacketNoSpamChatMessage.class,
+                PacketNoSpamChatMessage::toBytes,
+                PacketNoSpamChatMessage::new,
+                PacketNoSpamChatMessage::handle,
+                Optional.of(NetworkDirection.PLAY_TO_CLIENT));
     }
 
     public static void sendToNearby(World world, BlockPos pos, Object toSend){
@@ -116,4 +132,10 @@ public class Networking {
         sendToNearby(world, e.blockPosition(), toSend);
     }
 
+    public static void sendToPlayer(Object msg, PlayerEntity player) {
+        if (EffectiveSide.get() == LogicalSide.SERVER) {
+            ServerPlayerEntity serverPlayer = (ServerPlayerEntity) player;
+            INSTANCE.send(PacketDistributor.PLAYER.with(() -> serverPlayer), msg);
+        }
+    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/network/PacketNoSpamChatMessage.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/network/PacketNoSpamChatMessage.java
@@ -1,0 +1,70 @@
+package com.hollingsworth.arsnouveau.common.network;
+
+import com.hollingsworth.arsnouveau.ArsNouveau;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.NewChatGui;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraftforge.fml.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+/**
+ * A text message sent from player to client
+ */
+public class PacketNoSpamChatMessage {
+    private final ITextComponent message;
+    private final int messageChannelId;
+    private final boolean overlayMessage;
+
+    /** Base channel for messages sent via this packet. Must be unique among users of this feature. */
+    private static final int MESSAGE_ID = ArsNouveau.MODID.hashCode(); // -643241190
+
+    /**
+     * Creates a new packet to send a no-spam message to a player.
+     *
+     * Messages send to the player this way will not spam the chat log.
+     *
+     * @param message the message to send
+     * @param messageChannelId an offset from the base chat channel. Later messages with the same id will cause earlier
+     *                         ones to be deleted from the chat history, avoiding spam.
+     * @param overlayMessage if true, the message will instead be displayed briefly in the center of the screen just
+     *                       above the main bar.  If true, <code>messageChannelId</code> will be ignored.
+     */
+    public PacketNoSpamChatMessage(ITextComponent message, int messageChannelId, boolean overlayMessage) {
+        this.message = message;
+        this.messageChannelId = MESSAGE_ID + messageChannelId;
+        this.overlayMessage = overlayMessage;
+    }
+
+    // Decoder
+    public PacketNoSpamChatMessage(PacketBuffer buf) {
+        this.message = buf.readComponent();
+        this.messageChannelId = buf.readInt();
+        this.overlayMessage = buf.readBoolean();
+    }
+
+    // Encoder
+    public void toBytes(PacketBuffer buf) {
+        buf.writeComponent(message);
+        buf.writeInt(messageChannelId);
+        buf.writeBoolean(overlayMessage);
+    }
+
+    // Handler
+    public void handle(Supplier<NetworkEvent.Context> ctxSupplier) {
+        NetworkEvent.Context ctx = ctxSupplier.get();
+        ctx.enqueueWork(() -> {
+            // This packet is only registered to be received on the client
+            if (overlayMessage) {
+                if (Minecraft.getInstance().player != null) {
+                    Minecraft.getInstance().player.displayClientMessage(message, true);
+                }
+            } else {
+                NewChatGui gui = Minecraft.getInstance().gui.getChat();
+                gui.addMessage(message, messageChannelId);
+            }
+        });
+        ctx.setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/util/PortUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/util/PortUtil.java
@@ -1,5 +1,7 @@
 package com.hollingsworth.arsnouveau.common.util;
 
+import com.hollingsworth.arsnouveau.common.network.Networking;
+import com.hollingsworth.arsnouveau.common.network.PacketNoSpamChatMessage;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Util;
@@ -9,6 +11,18 @@ import net.minecraft.util.text.StringTextComponent;
 public class PortUtil {
     public static void sendMessage(Entity playerEntity, ITextComponent component){
         playerEntity.sendMessage(component, Util.NIL_UUID);
+    }
+
+    public static void sendMessageNoSpam(Entity playerEntity, ITextComponent component){
+        if (playerEntity instanceof PlayerEntity) {
+            Networking.sendToPlayer(new PacketNoSpamChatMessage(component, 0, false), (PlayerEntity) playerEntity);
+        }
+    }
+
+    public static void sendMessageCenterScreen(Entity playerEntity, ITextComponent component){
+        if (playerEntity instanceof PlayerEntity) {
+            Networking.sendToPlayer(new PacketNoSpamChatMessage(component, 0, true), (PlayerEntity) playerEntity);
+        }
     }
 
     public static void sendMessage(Entity playerEntity, String message){

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -11,3 +11,4 @@ public net.minecraft.potion.PotionBrewing func_193357_a(Lnet/minecraft/potion/Po
 public net.minecraft.world.Explosion *
 public-f net.minecraft.world.raid.Raid field_221359_w # numGroups
 public net.minecraft.entity.monster.ZombieVillagerEntity func_191991_a(Ljava/util/UUID;I)V # startConverting
+public net.minecraft.client.gui.NewChatGui func_146234_a(Lnet/minecraft/util/text/ITextComponent;I)V # addMessage


### PR DESCRIPTION
 * New Packet: PacketNoSpamChatMessage
   * When a client receives this packet, it will first delete any existing message with a matching id then display the contained message.
 * Converted SpellResolver and all ICasterItems to use the no-spam messaging.

Note: **Access transformers were changed!** Developers may need to refresh their gradle project.