### PR TITLE
Fix Bounce effect being applied to caster

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBounce.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBounce.java
@@ -24,7 +24,7 @@ public class EffectBounce extends AbstractEffect {
     public void onResolveEntity(EntityRayTraceResult rayTraceResult, World world, @Nullable LivingEntity shooter, SpellStats spellStats, SpellContext spellContext) {
         super.onResolveEntity(rayTraceResult, world, shooter, spellStats, spellContext);
         if(rayTraceResult.getEntity() instanceof LivingEntity){
-            applyConfigPotion(shooter, ModPotions.BOUNCE_EFFECT, spellStats);
+            applyConfigPotion((LivingEntity) rayTraceResult.getEntity(), ModPotions.BOUNCE_EFFECT, spellStats);
         }
     }
 


### PR DESCRIPTION
This attempts to address an issue regarding the newly added bounce effect being applied to spellcasters as opposed to the actual raytraced entity. Whether this was intentional or not is unknown to me, but if it was, feel free to ignore this, and apologies.