### PR TITLE
Fix pedestal rotation being independent from frametime

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ArcanePedestalRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ArcanePedestalRenderer.java
@@ -17,11 +17,11 @@ public class ArcanePedestalRenderer extends TileEntityRenderer<ArcanePedestalTil
         super(p_i226006_1_);
     }
 
-    public void renderFloatingItem(ArcanePedestalTile tileEntityIn, ItemEntity entityItem, double x, double y, double z, MatrixStack stack, IRenderTypeBuffer iRenderTypeBuffer, float partialFrames){
+    public void renderFloatingItem(ArcanePedestalTile tileEntityIn, ItemEntity entityItem, double x, double y, double z, MatrixStack stack, IRenderTypeBuffer iRenderTypeBuffer){
         stack.pushPose();
-        tileEntityIn.frames++;
+        tileEntityIn.frames += 1.5f * Minecraft.getInstance().getDeltaFrameTime();
         entityItem.setYHeadRot(tileEntityIn.frames);
-        ObfuscationReflectionHelper.setPrivateValue(ItemEntity.class, entityItem, (int) (800f - (tileEntityIn.frames + partialFrames)/2f), MappingUtil.getItemEntityAge());
+        ObfuscationReflectionHelper.setPrivateValue(ItemEntity.class, entityItem, (int) tileEntityIn.frames, MappingUtil.getItemEntityAge());
         Minecraft.getInstance().getEntityRenderDispatcher().render(entityItem, 0.5,1,0.5, entityItem.yRot, 2.0f,stack, iRenderTypeBuffer,15728880);
         Minecraft.getInstance().getEntityRenderDispatcher().getRenderer(entityItem);
         stack.popPose();
@@ -44,6 +44,6 @@ public class ArcanePedestalRenderer extends TileEntityRenderer<ArcanePedestalTil
         x = x + .5;
         y = y + 0.9;
         z = z +.5;
-        renderFloatingItem(tileEntityIn, entityItem, x, y , z, matrixStack, iRenderTypeBuffer, v);
+        renderFloatingItem(tileEntityIn, entityItem, x, y , z, matrixStack, iRenderTypeBuffer);
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ArcanePedestalTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ArcanePedestalTile.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 
 public class ArcanePedestalTile extends AnimatedTile implements IInventory {
     private final LazyOptional<IItemHandler> itemHandler = LazyOptional.of(() -> new InvWrapper(this));
-    public int frames;
+    public float frames;
     public ItemEntity entity;
     public ItemStack stack;
 


### PR DESCRIPTION
The entity rotation animation on the Arcane Pedestal moves too quickly or too slow depending on the framerate. These changes attempt to address the issue by introducing `getDeltaFrameTime()` from the Minecraft instance.

In the `tileEntityIn.frames` increment, a value of `1.5f` was chosen as the speed scalar, which if set to a value lower than 1, will determine the speed of the rotation, but may also appear choppy due to the actual rotation method needing to be casted to an int, I assume.

The increment I have set seems optimal enough, but if I have made an error or assumedly changed otherwise, I greatly apologize and am willing to re-edit based on input.

EDIT: Forgot to add a [demo video.](https://user-images.githubusercontent.com/9144208/132780987-c56e837f-f567-401a-a251-9092b1117807.mp4)

