### PR TITLE
Show which glyphs aren’t unlocked yet

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/SpellValidationError.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/SpellValidationError.java
@@ -13,6 +13,13 @@ import java.util.List;
  * This interface is not intended to be implemented by clients of the API.
  */
 public interface SpellValidationError {
+
+    /**
+     * Returns the maximum alpha value this glyph should have,
+     * if there are several validation errors the lowest value is used.
+     */
+    float getAlpha();
+
     /**
      * Returns the position this validation error refers to, or <code>-1</code> if the error indicates a problem with
      * the entire spell.

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GuiSpellBook.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GuiSpellBook.java
@@ -14,6 +14,7 @@ import com.hollingsworth.arsnouveau.common.network.Networking;
 import com.hollingsworth.arsnouveau.common.network.PacketUpdateSpellbook;
 import com.hollingsworth.arsnouveau.common.spell.validation.CombinedSpellValidator;
 import com.hollingsworth.arsnouveau.common.spell.validation.GlyphMaxTierValidator;
+import com.hollingsworth.arsnouveau.common.spell.validation.GlyphUnlockedValidator;
 import com.hollingsworth.arsnouveau.setup.ItemsRegistry;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.Minecraft;
@@ -77,7 +78,7 @@ public class GuiSpellBook extends BaseBook {
         allEffects = new ArrayList<>();
 
         // Pre-partition the known spell glyphs
-        for (AbstractSpellPart part : this.unlockedSpells) {
+        for (AbstractSpellPart part : ArsNouveauAPI.getInstance().getSpell_map().values()) {
             if (part instanceof AbstractCastMethod) {
                 this.castMethods.add(part);
             } else if (part instanceof AbstractAugment) {
@@ -94,7 +95,8 @@ public class GuiSpellBook extends BaseBook {
         this.validationErrors = new LinkedList<>();
         this.spellValidator = new CombinedSpellValidator(
                 api.getSpellCraftingSpellValidator(),
-                new GlyphMaxTierValidator(tier)
+                new GlyphMaxTierValidator(tier),
+                new GlyphUnlockedValidator(this.unlockedSpells)
         );
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
@@ -16,6 +16,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -63,7 +64,8 @@ public class GlyphButton extends Button {
                 if (validationErrors.isEmpty()) {
                     GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                 } else {
-                    GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.25F);
+                    GL11.glAlphaFunc(GL11.GL_GREATER, 0.01f);
+                    GL11.glColor4f(1.0F, 1.0F, 1.0F, validationErrors.stream().min(Comparator.comparing(SpellValidationError::getAlpha)).get().getAlpha());
                 }
 
                 GuiSpellBook.drawFromTexture(new ResourceLocation(ArsNouveau.MODID, "textures/items/" + this.resourceIcon), x, y, 0, 0, 16, 16,16,16 , ms);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/BaseSpellValidationError.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/BaseSpellValidationError.java
@@ -74,6 +74,11 @@ public class BaseSpellValidationError implements SpellValidationError {
     }
 
     @Override
+    public float getAlpha() {
+        return 0.5F;
+    }
+
+    @Override
     public int getPosition() {
         return position;
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/GlyphUnlockedValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/GlyphUnlockedValidator.java
@@ -1,0 +1,45 @@
+package com.hollingsworth.arsnouveau.common.spell.validation;
+
+import com.hollingsworth.arsnouveau.api.spell.*;
+import net.minecraft.util.*;
+
+import java.util.*;
+
+/**
+ * Spell validation that enforces that glyphs be unlocked.
+ *
+ * This validator is pulled in specially in {@link com.hollingsworth.arsnouveau.client.gui.book.GuiSpellBook}.
+ */
+public class GlyphUnlockedValidator extends ScanningSpellValidator<Unit> {
+    private final List<AbstractSpellPart> unlockedSpells;
+
+    /** Creates a glyph validator that will only accept glyphs that are present in this list. */
+    public GlyphUnlockedValidator(List<AbstractSpellPart> unlockedSpells) {
+        this.unlockedSpells = unlockedSpells;
+    }
+
+    @Override
+    protected Unit initContext() { return Unit.INSTANCE; }
+
+    @Override
+    protected void digestSpellPart(Unit context, int position, AbstractSpellPart spellPart, List<SpellValidationError> validationErrors) {
+        if(!unlockedSpells.contains(spellPart)) {
+            validationErrors.add(new GlyphUnlockedValidationError(position, spellPart, "glyph_unlock"));
+        }
+    }
+
+    @Override
+    protected void finish(Unit context, List<SpellValidationError> validationErrors) {}
+
+    public static class GlyphUnlockedValidationError extends BaseSpellValidationError {
+
+        @Override
+        public float getAlpha(){
+            return 0.05F;
+        }
+
+        public GlyphUnlockedValidationError(int position, AbstractSpellPart spellPart, String localizationCode) {
+            super(position, spellPart, localizationCode, spellPart);
+        }
+    }
+}

--- a/src/main/resources/assets/ars_nouveau/lang/en_us.json
+++ b/src/main/resources/assets/ars_nouveau/lang/en_us.json
@@ -655,6 +655,7 @@
 	"ars_nouveau.spell.validation.exists.glyph_occurrences_policy": "%s appears too many times.",
 	"ars_nouveau.spell.validation.exists.augment_compatibility": "%s cannot be augmented by %s",
 	"ars_nouveau.spell.validation.exists.glyph_tier": "%s is too powerful for your current spell book.",
+	"ars_nouveau.spell.validation.exists.glyph_unlock": "%s is not yet unlocked in your current spell book.",
 
 	"ars_nouveau.spell.validation.adding._comment": "__ These messages appear when attempting to add a glyph that would make a spell invalid. __",
 	"ars_nouveau.spell.validation.adding.non_empty_spell": "The spell may not be empty.",
@@ -665,6 +666,7 @@
 	"ars_nouveau.spell.validation.adding.glyph_occurrences_policy": "%s has appeared its maximum number of times.",
 	"ars_nouveau.spell.validation.adding.augment_compatibility": "%s cannot be augmented by %s",
 	"ars_nouveau.spell.validation.adding.glyph_tier": "%s is too powerful for your current spell book.",
+    "ars_nouveau.spell.validation.adding.glyph_unlock": "%s is not yet unlocked in your current spell book.",
 
 	"ars_nouveau.spell.no_mana": "Not enough Mana.",
 	"block.ars_nouveau.potion_jar": "Potion Jar",


### PR DESCRIPTION
hi,

enjoying the mod when playing the enigmatica 6 modpack, but one thing irks me a bit: there is no easy way to see which glyphs aren't unlocked yet in your current spellbook, its a bit annoying when trying to find new glyphs or maximizing mana.

i made a small draft which makes all glyphs show but invalidates those that aren't unlocked yet, which are also more transparent than the usual validation errors to make them stand out more.

i don't expect this to get merged as-is since it probably clashes with something (like maybe you not wanting to show all the glyhps there but rather on a tab of its own), but it would be very nice to see a feature get added that shows unlockables.

![2021-10-25_15 52 54](https://user-images.githubusercontent.com/3179271/138709832-bb37c8ec-80a8-46fb-a97b-d6b254718836.png)