### PR TITLE
Clear the spell's name when clear is pressed twice

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GuiSpellBook.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GuiSpellBook.java
@@ -360,9 +360,15 @@ public class GuiSpellBook extends BaseBook {
     }
 
     public void clear(Button button){
+        boolean allWereEmpty = true;
+
         for (CraftingButton slot : craftingCells) {
+            if(!slot.spellTag.equals("")) allWereEmpty = false;
             slot.clear();
         }
+
+        if (allWereEmpty) spell_name.setValue("");
+
         validate();
     }
 


### PR DESCRIPTION
i noticed i edited & replaced spells a lot, would be nice of the clear button also erased the typed name, a bit of a QOL thing 🤔 