### PR TITLE
Bugfix:  React Enchantment.

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/ArsNouveauAPI.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/ArsNouveauAPI.java
@@ -1,6 +1,7 @@
 package com.hollingsworth.arsnouveau.api;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.enchanting_apparatus.EnchantingApparatusRecipe;
 import com.hollingsworth.arsnouveau.api.enchanting_apparatus.IEnchantingRecipe;
 import com.hollingsworth.arsnouveau.api.familiar.AbstractFamiliarHolder;
 import com.hollingsworth.arsnouveau.api.recipe.GlyphPressRecipe;
@@ -21,6 +22,7 @@ import com.hollingsworth.arsnouveau.setup.ItemsRegistry;
 import com.hollingsworth.arsnouveau.setup.RecipeRegistry;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.RecipeManager;
 import net.minecraft.util.ResourceLocation;
@@ -201,7 +203,14 @@ public class ArsNouveauAPI {
     }
 
     public List<IEnchantingRecipe> getEnchantingApparatusRecipes(World world) {
-        return world.getRecipeManager().getAllRecipesFor(RecipeRegistry.APPARATUS_TYPE);
+        List<IEnchantingRecipe> recipes = new ArrayList<>(enchantingApparatusRecipes);
+        RecipeManager manager = world.getRecipeManager();
+        for(IRecipe i : manager.getRecipes()){
+            if(i instanceof EnchantingApparatusRecipe){
+                recipes.add((IEnchantingRecipe) i);
+            }
+        }
+        return recipes;
     }
 
     public @Nullable GlyphPressRecipe getGlyphPressRecipe(World world, Item reagent, @Nullable ISpellTier.Tier tier){

--- a/src/main/java/com/hollingsworth/arsnouveau/api/enchanting_apparatus/SpellWriteRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/enchanting_apparatus/SpellWriteRecipe.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.api.enchanting_apparatus;
 
+import com.hollingsworth.arsnouveau.api.spell.SpellCaster;
 import com.hollingsworth.arsnouveau.common.block.tile.EnchantingApparatusTile;
 import com.hollingsworth.arsnouveau.common.enchantment.EnchantmentRegistry;
 import com.hollingsworth.arsnouveau.common.items.SpellParchment;
@@ -39,7 +40,8 @@ public class SpellWriteRecipe extends EnchantingApparatusRecipe{
     public ItemStack getResult(List<ItemStack> pedestalItems, ItemStack reagent, EnchantingApparatusTile enchantingApparatusTile) {
         CompoundNBT tag = reagent.getOrCreateTag();
         ItemStack parchment = getParchment(pedestalItems);
-        tag.putString("spell", parchment.getOrCreateTag().getString("spell"));
+        tag.putString("spell", SpellParchment.getSpell(parchment).serialize());
+        tag.putString("spell_color", SpellCaster.deserialize(parchment).getColor().serialize());
         reagent.setTag(tag);
         return reagent.copy();
     }


### PR DESCRIPTION
-fixed the bug where all enchantments per enchanting apparatus were broken by reverting to the noncached Recipies for the enchanting apparatus (https://github.com/baileyholl/Ars-Nouveau/issues/398)
-fixed the bug were Writing the spell into an React item would fail by copying the way its inscribed Originaly