### PR TITLE
Fix #474

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/RadialMenu/GuiRadialMenu.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/RadialMenu/GuiRadialMenu.java
@@ -229,7 +229,7 @@ public class GuiRadialMenu<T> extends Screen {
     @Override
     public boolean mouseClicked(double p_mouseClicked_1_, double p_mouseClicked_3_, int p_mouseClicked_5_) {
         if (this.selectedItem != -1) {
-            radialMenu.setCurrentSlot(selectedItem + 1); // Caller expects slot index starting with 1, while internally we're using 0 based indexing
+            radialMenu.setCurrentSlot(selectedItem);
             minecraft.player.closeContainer();
         }
         return true;


### PR DESCRIPTION
Removes +1 in spell selection. Comment said that this +1 was intentional but actually it caused problems and removing it worked just fine without causing other bugs.