### PR TITLE
Replaced Gl11 Function in ItemRendering with RenderSystem function

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/utils/RenderUtils.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/utils/RenderUtils.java
@@ -9,6 +9,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiComponent;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.entity.ItemRenderer;
@@ -60,12 +61,16 @@ public class RenderUtils {
         }
 
         if (renderTransparent) {
-            RenderSystem.depthMask(true);
-            GL11.glEnable(GL11.GL_ALPHA_TEST);
+            RenderSystem.depthMask(true);;
+            RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
         }
 
         poseStack.popPose();
         RenderSystem.applyModelViewMatrix();
+        if(renderTransparent) {
+            RenderSystem.disableBlend();
+            RenderSystem.defaultBlendFunc();
+        }
     }
 
     private static MultiBufferSource transparentBuffer(MultiBufferSource buffer) {


### PR DESCRIPTION
Not 100% if this is really the change needed to fix the Gl11 problem, but it still renders unlocked Glyphs in GlyphUnlock transparent and uses RenderSystem so it should be right?
Merge with care, probably!