### PR TITLE
Replaced Gl11 Function in ItemRendering with RenderSystem function

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/utils/RenderUtils.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/utils/RenderUtils.java
@@ -11,6 +11,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiComponent;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.entity.ItemRenderer;
@@ -66,12 +67,16 @@ public class RenderUtils {
         }
 
         if (renderTransparent) {
-            GL11.glDepthMask(true);
-            GL11.glEnable(GL11.GL_ALPHA_TEST);
+            RenderSystem.depthMask(true);;
+            RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
         }
 
         poseStack.popPose();
         RenderSystem.applyModelViewMatrix();
+        if(renderTransparent) {
+            RenderSystem.disableBlend();
+            RenderSystem.defaultBlendFunc();
+        }
     }
 
     private static MultiBufferSource transparentBuffer(MultiBufferSource buffer) {


### PR DESCRIPTION
It's a little more transparent than the icon rendered ones, but I'm not sure if I can change that.
![image](https://user-images.githubusercontent.com/31982384/176022174-e0b76648-b7b1-4b4b-b4cb-9352c76ec5e5.png)
Might have been like that since I did ItemRender as well, I'm not sure anymore