### PR TITLE
Mana Attributes

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/item/ArsNouveauCurio.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/item/ArsNouveauCurio.java
@@ -2,6 +2,8 @@ package com.hollingsworth.arsnouveau.api.item;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
 import com.hollingsworth.arsnouveau.common.items.ModItem;
+import net.minecraft.world.item.ItemStack;
+import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 
@@ -16,4 +18,8 @@ public abstract class ArsNouveauCurio extends ModItem implements ICurioItem {
         super(properties);
     }
 
+    @Override
+    public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
+        return true;
+    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/api/mana/ManaAttributes.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/mana/ManaAttributes.java
@@ -1,0 +1,40 @@
+package com.hollingsworth.arsnouveau.api.mana;
+
+import com.hollingsworth.arsnouveau.ArsNouveau;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.RangedAttribute;
+import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.function.Function;
+
+@Mod.EventBusSubscriber(modid = ArsNouveau.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class ManaAttributes {
+    public static final HashMap<RegistryObject<Attribute>, UUID> UUIDS = new HashMap<>();
+    public static final DeferredRegister<Attribute> ATTRIBUTES = DeferredRegister.create(ForgeRegistries.ATTRIBUTES,ArsNouveau.MODID);
+
+    public static final RegistryObject<Attribute> MANA_REGEN = registerAttribute("mana_regen",(id) -> new RangedAttribute(id, 0.0D, 0.0D, 2000.0D).setSyncable(true));
+    public static final RegistryObject<Attribute> MAX_MANA = registerAttribute("max_mana",(id) -> new RangedAttribute(id, 0.0D, 0.0D, 10000.0D).setSyncable(true));;
+
+    public static RegistryObject<Attribute> registerAttribute(String name, Function<String, Attribute> attribute) {
+        RegistryObject<Attribute> registryObject = ATTRIBUTES.register(name, () -> attribute.apply("attribute.name.ars_nouveau." + name));
+        UUIDS.put(registryObject, UUID.randomUUID());
+        return registryObject;
+    }
+
+    @SubscribeEvent
+    public static void modifyEntityAttributes(EntityAttributeModificationEvent event) {
+        event.getTypes().stream().filter(e -> e == EntityType.PLAYER).forEach(e -> {
+            event.add(e, MAX_MANA.get());
+            event.add(e, MANA_REGEN.get());
+        });
+    }
+
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/ManaUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/ManaUtil.java
@@ -4,31 +4,27 @@ import com.hollingsworth.arsnouveau.api.event.ManaRegenCalcEvent;
 import com.hollingsworth.arsnouveau.api.event.MaxManaCalcEvent;
 import com.hollingsworth.arsnouveau.api.mana.IManaCap;
 import com.hollingsworth.arsnouveau.api.mana.IManaEquipment;
-import com.hollingsworth.arsnouveau.common.armor.MagicArmor;
+import com.hollingsworth.arsnouveau.api.mana.ManaAttributes;
 import com.hollingsworth.arsnouveau.common.capability.CapabilityRegistry;
 import com.hollingsworth.arsnouveau.common.enchantment.EnchantmentRegistry;
 import com.hollingsworth.arsnouveau.common.potions.ModPotions;
 import com.hollingsworth.arsnouveau.setup.Config;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.items.IItemHandlerModifiable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ManaUtil {
 
-
     public static int getPlayerDiscounts(LivingEntity e) {
         AtomicInteger discounts = new AtomicInteger();
         CuriosUtil.getAllWornItems(e).ifPresent(items -> {
-
             for (int i = 0; i < items.getSlots(); i++) {
-                Item item = items.getStackInSlot(i).getItem();
-                if (item instanceof IManaEquipment)
-                    discounts.addAndGet(((IManaEquipment) item).getManaDiscount(items.getStackInSlot(i)));
+                ItemStack item = items.getStackInSlot(i);
+                if (item.getItem() instanceof IManaEquipment discountItem )
+                    discounts.addAndGet(discountItem.getManaDiscount(item));
             }
         });
         return discounts.get();
@@ -45,21 +41,14 @@ public class ManaUtil {
         IManaCap mana = CapabilityRegistry.getMana(e).orElse(null);
         if (mana == null)
             return 0;
-        int max = Config.INIT_MAX_MANA.get();
-        for (ItemStack i : e.getAllSlots()) {
-            if (i.getItem() instanceof IManaEquipment) {
-                max += (((IManaEquipment) i.getItem()).getMaxManaBoost(i));
-            }
-            max += (Config.MANA_BOOST_BONUS.get() * i.getEnchantmentLevel(EnchantmentRegistry.MANA_BOOST_ENCHANTMENT.get()));
-        }
 
-        IItemHandlerModifiable items = CuriosUtil.getAllWornItems(e).orElse(null);
-        if (items != null) {
-            for (int i = 0; i < items.getSlots(); i++) {
-                Item item = items.getStackInSlot(i).getItem();
-                if (item instanceof IManaEquipment iMana)
-                    max += iMana.getMaxManaBoost(items.getStackInSlot(i));
-            }
+        int max = Config.INIT_MAX_MANA.get();
+
+        if (e.getAttribute(ManaAttributes.MAX_MANA.get()) != null)
+            max += e.getAttributeValue(ManaAttributes.MAX_MANA.get());
+
+        for(ItemStack i : e.getAllSlots()){
+            max += (Config.MANA_BOOST_BONUS.get() * i.getEnchantmentLevel(EnchantmentRegistry.MANA_BOOST_ENCHANTMENT.get()));
         }
 
         int tier = mana.getBookTier();
@@ -75,24 +64,16 @@ public class ManaUtil {
 
     public static double getManaRegen(Player e) {
         IManaCap mana = CapabilityRegistry.getMana(e).orElse(null);
-        if (mana == null)
-            return 0;
+
+        if(mana == null) return 0;
         double regen = Config.INIT_MANA_REGEN.get();
-        for (ItemStack i : e.getAllSlots()) {
-            if (i.getItem() instanceof MagicArmor armor) {
-                regen += armor.getManaRegenBonus(i);
-            }
+
+        if (e.getAttribute(ManaAttributes.MANA_REGEN.get()) != null)
+            regen += e.getAttributeValue(ManaAttributes.MANA_REGEN.get());
+
+        for(ItemStack i : e.getAllSlots()){
             regen += Config.MANA_REGEN_ENCHANT_BONUS.get() * i.getEnchantmentLevel(EnchantmentRegistry.MANA_REGEN_ENCHANTMENT.get());
         }
-        IItemHandlerModifiable items = CuriosUtil.getAllWornItems(e).orElse(null);
-        if (items != null) {
-            for (int i = 0; i < items.getSlots(); i++) {
-                Item item = items.getStackInSlot(i).getItem();
-                if (item instanceof IManaEquipment)
-                    regen += ((IManaEquipment) item).getManaRegenBonus(items.getStackInSlot(i));
-            }
-        }
-
         int tier = mana.getBookTier();
         double numGlyphs = mana.getGlyphBonus();
         regen += numGlyphs * Config.GLYPH_REGEN_BONUS.get();
@@ -104,4 +85,5 @@ public class ManaUtil {
         regen = event.getRegen();
         return regen;
     }
+
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/armor/MagicArmor.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/armor/MagicArmor.java
@@ -1,13 +1,20 @@
 package com.hollingsworth.arsnouveau.common.armor;
 
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import com.hollingsworth.arsnouveau.api.mana.IManaEquipment;
+import com.hollingsworth.arsnouveau.api.mana.ManaAttributes;
 import com.hollingsworth.arsnouveau.common.capability.CapabilityRegistry;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+
+import java.util.UUID;
 
 public abstract class MagicArmor extends ArmorItem implements IManaEquipment {
 
@@ -27,4 +34,17 @@ public abstract class MagicArmor extends ArmorItem implements IManaEquipment {
             }
         });
     }
+
+    @Override
+    public Multimap<Attribute, AttributeModifier> getAttributeModifiers(EquipmentSlot pEquipmentSlot, ItemStack stack) {
+        ImmutableMultimap.Builder<Attribute, AttributeModifier> attributes = new ImmutableMultimap.Builder<>();
+        attributes.putAll(super.getDefaultAttributeModifiers(pEquipmentSlot));
+        if (this.slot == pEquipmentSlot) {
+            UUID uuid = ARMOR_MODIFIER_UUID_PER_SLOT[slot.getIndex()];
+            attributes.put(ManaAttributes.MAX_MANA.get(), new AttributeModifier(uuid, "max_mana_armor", this.getMaxManaBoost(stack), AttributeModifier.Operation.ADDITION));
+            attributes.put(ManaAttributes.MANA_REGEN.get(), new AttributeModifier(uuid, "mana_regen_armor", this.getManaRegenBonus(stack), AttributeModifier.Operation.ADDITION));
+        }
+        return attributes.build();
+    }
+
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/curios/AbstractManaCurio.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/curios/AbstractManaCurio.java
@@ -1,11 +1,27 @@
 package com.hollingsworth.arsnouveau.common.items.curios;
 
+import com.google.common.collect.Multimap;
 import com.hollingsworth.arsnouveau.api.item.ArsNouveauCurio;
 import com.hollingsworth.arsnouveau.api.mana.IManaEquipment;
+import com.hollingsworth.arsnouveau.api.mana.ManaAttributes;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.item.ItemStack;
+import top.theillusivec4.curios.api.SlotContext;
+
+import java.util.UUID;
 
 public abstract class AbstractManaCurio extends ArsNouveauCurio implements IManaEquipment {
     public AbstractManaCurio() {
         super();
+    }
+
+    @Override
+    public Multimap<Attribute, AttributeModifier> getAttributeModifiers(SlotContext slotContext, UUID uuid, ItemStack stack) {
+        Multimap<Attribute, AttributeModifier> attributes = super.getAttributeModifiers(slotContext, uuid, stack);
+        attributes.put(ManaAttributes.MAX_MANA.get(), new AttributeModifier(uuid, "max_mana_modifier_curio" ,this.getMaxManaBoost(stack), AttributeModifier.Operation.ADDITION) );
+        attributes.put(ManaAttributes.MANA_REGEN.get(), new AttributeModifier(uuid, "mana_regen_modifier_curio" ,this.getManaRegenBonus(stack), AttributeModifier.Operation.ADDITION) );
+        return attributes;
     }
 
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/setup/ModSetup.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/setup/ModSetup.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.setup;
 
+import com.hollingsworth.arsnouveau.api.mana.ManaAttributes;
 import com.hollingsworth.arsnouveau.client.particle.ModParticles;
 import com.hollingsworth.arsnouveau.common.enchantment.EnchantmentRegistry;
 import com.hollingsworth.arsnouveau.common.entity.ModEntities;
@@ -54,6 +55,7 @@ public class ModSetup {
         RecipeRegistry.RECIPE_SERIALIZERS.register(modEventBus);
         RecipeRegistry.RECIPE_TYPES.register(modEventBus);
         ModParticles.PARTICLES.register(modEventBus);
+        ManaAttributes.ATTRIBUTES.register(modEventBus);
         TRUNK_PLACER_TYPE_DEFERRED_REGISTER.register(modEventBus);
         Deferred.FEAT_REG.register(modEventBus);
         Deferred.CONFG_REG.register(modEventBus);

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -16,6 +16,7 @@ public net.minecraft.world.food.FoodData f_38697_ #saturationLevel
 public net.minecraft.world.entity.Mob f_21342_ # moveControl
 public net.minecraft.world.entity.player.Player f_36093_ # inventory
 public net.minecraft.world.entity.player.Player f_36077_ # abilities
+protected net.minecraft.world.item.ArmorItem f_40380_ # ARMOR_MODIFIER_UUID_PER_SLOTpublic net.minecraft.world.entity.Entity f_19825_ # positionVec
 public net.minecraft.world.entity.Entity f_19858_ # xRot
 public net.minecraft.world.entity.Entity f_19857_ # yRot
 public net.minecraft.world.entity.item.ItemEntity f_31985_ # age

--- a/src/main/resources/assets/ars_nouveau/lang/en_us.json
+++ b/src/main/resources/assets/ars_nouveau/lang/en_us.json
@@ -13,6 +13,10 @@
 	"enchantment.ars_nouveau.mana_regen.desc": "Increases the mana regeneration of the player.",
 	"enchantment.ars_nouveau.mana_boost.desc": "Increases the maximum mana of the player.",
 	"enchantment.ars_nouveau.reactive.desc": "Has a chance to cast the inscribed spell on tool use or player hurt.",
+
+	"attribute.name.ars_nouveau.mana_regen": "Mana Regeneration",
+	"attribute.name.ars_nouveau.max_mana": "Max Mana",
+
 	"entity.ars_nouveau.bookwyrm": "Bookwyrm",
 	"entity.ars_nouveau.starbuncle": "Starbuncle",
 	"item.ars_nouveau.archmage_robes":"Archmage Robes",


### PR DESCRIPTION
Converts the max mana and mana regen buffs from curio and armors into an attribute. Breaking change for addons.
On curio side, the attribute modifiers can be added with the ICurio#getAttributeModifiers(SlotContext, UUID, ItemStack) method.
For armors, and other items to held or wear, IForgeItem#getAttributeModifiers(EquipmentSlot, ItemStack).

This allows caching on the entity data of the values, instead of scanning the player inventories at every calculation (for the armor is still needed to check enchants), allows to use commands to set specific values on the player or generate items with mana attributes modifiers in the nbt tag.

Classes extending MagicArmor and AbstractManaCurio will keep behaving as intended. IManaEquipment will become deprecated for max mana/regen and only used for cast discount. 
