### PR TITLE
Prevent summoned skeletons from dropping loot

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/SummonSkeleton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/SummonSkeleton.java
@@ -272,6 +272,11 @@ public class SummonSkeleton extends Skeleton implements IFollowingSummon, ISummo
         this.entityData.set(OWNER_UNIQUE_ID, Optional.ofNullable(uuid));
     }
 
+    @Override
+    protected boolean shouldDropLoot() {
+        return false;
+    }
+
     class CopyOwnerTargetGoal extends TargetGoal {
 
         public CopyOwnerTargetGoal(PathfinderMob creature) {


### PR DESCRIPTION
A summoned skeleton has a chance of dropping the weapon they are holding upon death. This can be potentially gamebreaking as other mods that have the ability to deconstruct the materials of tools can be exploited easily through this method.

I suppose it's a bit nitpicky to consider, as one would argue if someone would need it for something like netherite farming. Nevertheless, if it's an intended choice I do apologize for the confusion.

Take care.