### PR TITLE
FamiliarData fix

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarEntity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarEntity.java
@@ -43,8 +43,6 @@ import software.bernie.geckolib3.core.manager.AnimationFactory;
 import javax.annotation.Nullable;
 import java.util.*;
 
-import net.minecraft.world.entity.Entity.RemovalReason;
-
 public class FamiliarEntity extends PathfinderMob implements IAnimatable, IFamiliar, IDispellable, IDecoratable {
 
     public double manaReserveModifier = 0.15;
@@ -181,12 +179,17 @@ public class FamiliarEntity extends PathfinderMob implements IAnimatable, IFamil
         return this.entityData.get(COSMETIC);
     }
 
-    public void setCosmeticItem(ItemStack stack) {
-        if (!this.entityData.get(COSMETIC).isEmpty())
+    //use this for tag reload
+    public void setCosmeticItem(ItemStack stack, boolean shouldDrop) {
+        if (!this.entityData.get(COSMETIC).isEmpty() && shouldDrop)
             this.level.addFreshEntity(new ItemEntity(this.level, this.getX(), this.getY(), this.getZ(), this.entityData.get(COSMETIC)));
         this.entityData.set(COSMETIC, stack);
         this.persistentData.cosmetic = stack;
         syncTag();
+    }
+
+    public void setCosmeticItem(ItemStack stack) {
+        setCosmeticItem(stack, true);
     }
 
     @Override
@@ -315,7 +318,7 @@ public class FamiliarEntity extends PathfinderMob implements IAnimatable, IFamil
             setColor(persistentData.color);
         }
         if (persistentData.cosmetic != null) {
-            setCosmeticItem(persistentData.cosmetic);
+            setCosmeticItem(persistentData.cosmetic, false);
         }
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarStarbuncle.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarStarbuncle.java
@@ -5,7 +5,6 @@ import com.hollingsworth.arsnouveau.api.scrying.TagScryer;
 import com.hollingsworth.arsnouveau.common.entity.ModEntities;
 import com.hollingsworth.arsnouveau.common.entity.Starbuncle;
 import com.hollingsworth.arsnouveau.common.ritual.RitualScrying;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionHand;
@@ -85,13 +84,4 @@ public class FamiliarStarbuncle extends FamiliarEntity {
         return ModEntities.ENTITY_FAMILIAR_STARBUNCLE.get();
     }
 
-    @Override
-    public Starbuncle.StarbuncleData getPersistentFamiliarData() {
-        return (Starbuncle.StarbuncleData) this.persistentData;
-    }
-
-    @Override
-    public Starbuncle.StarbuncleData deserializePersistentData(CompoundTag tag) {
-        return new Starbuncle.StarbuncleData(tag);
-    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/WixieHat.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/WixieHat.java
@@ -1,9 +1,11 @@
 package com.hollingsworth.arsnouveau.common.items;
 
+import com.hollingsworth.arsnouveau.api.entity.IDecoratable;
 import com.hollingsworth.arsnouveau.api.item.ICosmeticItem;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemRenderer;
 import com.hollingsworth.arsnouveau.client.renderer.tile.GenericModel;
 import com.hollingsworth.arsnouveau.common.entity.Starbuncle;
+import com.hollingsworth.arsnouveau.common.entity.familiar.FamiliarStarbuncle;
 import com.hollingsworth.arsnouveau.common.entity.goal.carbuncle.StarbyPotionBehavior;
 import com.hollingsworth.arsnouveau.common.util.PortUtil;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
@@ -25,10 +27,12 @@ public class WixieHat extends AnimModItem implements ICosmeticItem {
 
     @Override
     public InteractionResult interactLivingEntity(ItemStack pStack, Player pPlayer, LivingEntity pInteractionTarget, InteractionHand pUsedHand) {
-        if(pInteractionTarget instanceof Starbuncle starbuncle){
+        if (pInteractionTarget instanceof Starbuncle starbuncle) {
             starbuncle.setBehavior(new StarbyPotionBehavior(starbuncle, new CompoundTag()));
             PortUtil.sendMessage(pPlayer, Component.translatable("ars_nouveau.starbuncle.potion_behavior_set"));
-            starbuncle.setCosmeticItem(pStack.split(1));
+        }
+        if (pInteractionTarget instanceof IDecoratable toWix && canWear(pInteractionTarget)) {
+            toWix.setCosmeticItem(pStack.split(1));
             return InteractionResult.SUCCESS;
         }
         return super.interactLivingEntity(pStack, pPlayer, pInteractionTarget, pUsedHand);
@@ -65,7 +69,7 @@ public class WixieHat extends AnimModItem implements ICosmeticItem {
 
     @Override
     public boolean canWear(LivingEntity entity) {
-        return entity instanceof Starbuncle;
+        return entity instanceof Starbuncle || entity instanceof FamiliarStarbuncle;
     }
 
     @Override


### PR DESCRIPTION
Make the Starbuncle familiar use the standard FamiliarData instead of the StarbuncleData that is way more complex now.
Fix Familiars duping their cosmetic items.
Wix the starby fam.