### PR TITLE
Show amounts in source and potion jar models

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/ClientHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/ClientHandler.java
@@ -25,6 +25,7 @@ import net.minecraft.client.renderer.entity.*;
 import net.minecraft.client.renderer.item.ClampedItemPropertyFunction;
 import net.minecraft.client.renderer.item.ItemProperties;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
@@ -185,6 +186,14 @@ public class ClientHandler {
                         default -> 1.0f;
                     };
                 }
+            });
+            ItemProperties.register(BlockRegistry.POTION_JAR.asItem(), new ResourceLocation(ArsNouveau.MODID, "amount"), (stack, level, entity, seed) -> {
+                CompoundTag tag = stack.getTag();
+                return tag != null ? (tag.getCompound("BlockEntityTag").getInt("amount") / 10000.0F) : 0.0F;
+            });
+            ItemProperties.register(BlockRegistry.SOURCE_JAR.asItem(), new ResourceLocation(ArsNouveau.MODID, "source"), (stack, level, entity, seed) -> {
+                CompoundTag tag = stack.getTag();
+                return tag != null ? (tag.getCompound("BlockEntityTag").getInt("source") / 10000.0F) : 0.0F; 
             });
         });
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/ClientHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/ClientHandler.java
@@ -221,6 +221,18 @@ public class ClientHandler {
                 reader != null && pos != null && reader.getBlockEntity(pos) instanceof PotionJarTile
                         ? ((PotionJarTile) reader.getBlockEntity(pos)).getColor()
                         : -1, BlockRegistry.POTION_JAR);
+
+        event.getItemColors().register((stack, color) -> {
+            if (color > 0) {
+                return -1;
+            }
+            CompoundTag tag = stack.getTag();
+            tag = tag != null ? tag.getCompound("BlockEntityTag") : null;
+            if (tag != null && PotionUtils.getPotion(tag) != Potions.EMPTY) {
+                return PotionUtils.getColor(PotionUtils.getAllEffects(tag));
+            }
+            return -1;
+        }, BlockRegistry.POTION_JAR);
     }
 
     public static void cameraOverlay(ForgeIngameGui gui, PoseStack pose, float partialTicks, int width, int height) {

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar10.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar10.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar100.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar100.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar20.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar20.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar30.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar30.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar40.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar40.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar50.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar50.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar60.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar60.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar70.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar70.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar80.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar80.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar90.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar90.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar_sliver.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/potion_jar/potion_jar_sliver.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"textures": {
 		"2": "ars_nouveau:blocks/potion_jar",
 		"3": "ars_nouveau:blocks/potion_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar10.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar10.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar100.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar100.json
@@ -1,6 +1,7 @@
 {
 	"credit": "Made with Blockbench",
 	"parent": "block/cube_all",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar20.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar20.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar30.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar30.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar40.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar40.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar50.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar50.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar60.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar60.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar70.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar70.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar80.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar80.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar90.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar90.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar_sliver.json
+++ b/src/main/resources/assets/ars_nouveau/models/block/source_jar/source_jar_sliver.json
@@ -1,5 +1,6 @@
 {
 	"credit": "Made with Blockbench",
+	"parent": "block/cube_all",
 	"texture_size": [64, 64],
 	"textures": {
 		"0": "ars_nouveau:blocks/mana_still",

--- a/src/main/resources/assets/ars_nouveau/models/item/potion_jar.json
+++ b/src/main/resources/assets/ars_nouveau/models/item/potion_jar.json
@@ -1,4 +1,71 @@
 {
-  "parent": "ars_nouveau:block/potion_jar/potion_jar_0"
+  "parent": "ars_nouveau:block/potion_jar/potion_jar_0",
+  "overrides": [
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.01
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar_sliver"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.10
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar10"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.20
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar20"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.30
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar30"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.40
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar40"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.50
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar50"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.60
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar60"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.70
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar80"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.80
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar80"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 0.90
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar90"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:amount": 1.00
+      },
+      "model": "ars_nouveau:block/potion_jar/potion_jar100"
+    }
+  ]
 }
-

--- a/src/main/resources/assets/ars_nouveau/models/item/source_jar.json
+++ b/src/main/resources/assets/ars_nouveau/models/item/source_jar.json
@@ -1,4 +1,71 @@
 {
-  "parent": "ars_nouveau:block/source_jar/source_jar0"
+  "parent": "ars_nouveau:block/source_jar/source_jar0",
+  "overrides": [
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.01
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar_sliver"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.10
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar10"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.20
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar20"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.30
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar30"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.40
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar40"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.50
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar50"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.60
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar60"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.70
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar80"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.80
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar80"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 0.90
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar90"
+    },
+    {
+      "predicate": {
+        "ars_nouveau:source": 1.00
+      },
+      "model": "ars_nouveau:block/source_jar/source_jar100"
+    }
+  ]
 }
-


### PR DESCRIPTION
![A screenshot of container slots containing source and potion jars, each showing their respective source level in the item model](https://user-images.githubusercontent.com/9869940/186029271-0ddb467e-8314-435c-b376-2dd6dae43e98.png)

Introduces two new item model properties for measuring the contents of source and potion jars. The item models have been expanded to include predicates for these properties, which determine the model to use based on the contents. The overrides delegate to the block models, and each previously unused block model has had a block/block parent defined in order to correct their transforms when rendered in item form. A color provider for the potion jar has also been added to ensure that the contents are displayed in the correct color.