### PR TITLE
Fix missing tooltip on potion jar item

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/setup/BlockRegistry.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/setup/BlockRegistry.java
@@ -519,7 +519,7 @@ public class BlockRegistry {
             registry.register(getDefaultBlockItem(BlockRegistry.SOURCE_GEM_BLOCK, LibBlockNames.SOURCE_GEM_BLOCK));
             ComposterBlock.COMPOSTABLES.put(BlockRegistry.MAGE_BLOOM_CROP.asItem(), 0.3f);
 
-            registry.register(getDefaultBlockItem(BlockRegistry.POTION_JAR, LibBlockNames.POTION_JAR_BLOCK));
+            registry.register(new BlockItem(BlockRegistry.POTION_JAR, ItemsRegistry.defaultItemProperties()).setRegistryName(LibBlockNames.POTION_JAR_BLOCK));
             registry.register(new RendererBlockItem(BlockRegistry.POTION_MELDER, ItemsRegistry.defaultItemProperties()) {
                 @Override
                 public Supplier<BlockEntityWithoutLevelRenderer> getRenderer() {


### PR DESCRIPTION
![A screenshot of the potion jar tooltip](https://user-images.githubusercontent.com/9869940/186031103-7e2aa91e-7791-44d8-8a55-1f56c8151d4b.png)

The item is currently being created using ModBlockItem which overrides the default tooltip logic and prevents the tooltip defined in the block class from ever being appended. The simplest fix for this is to use BlockItem, as the potion jar was not using any of the methods added by ModBlockItem anyway.