### PR TITLE
Add configs to toggle self-effects from spells like flare

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
@@ -199,6 +199,7 @@ public abstract class AbstractEffect extends AbstractSpellPart {
     public ForgeConfigSpec.IntValue EXTEND_TIME;
     public ForgeConfigSpec.IntValue GENERIC_INT;
     public ForgeConfigSpec.DoubleValue GENERIC_DOUBLE;
+    public ForgeConfigSpec.BooleanValue CASTER_AFFECTED;
 
     @Override
     public void buildConfig(ForgeConfigSpec.Builder builder) {
@@ -233,6 +234,10 @@ public abstract class AbstractEffect extends AbstractSpellPart {
     public void addDefaultPotionConfig(ForgeConfigSpec.Builder builder) {
         addPotionConfig(builder, 30);
         addExtendTimeConfig(builder, 8);
+    }
+
+    public void addCasterAffectedConfig(ForgeConfigSpec.Builder builder, boolean defaultValue) {
+	CASTER_AFFECTED = builder.comment("Whether this effect affects its own caster").define("caster_affected", defaultValue);
     }
 
     @Deprecated(forRemoval = true, since = "3.4.0")

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectColdSnap.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectColdSnap.java
@@ -49,7 +49,7 @@ public class EffectColdSnap extends AbstractEffect implements IDamageEffect {
         damage(vec, world, shooter, spellStats, damage, snareSec, livingEntity);
 
         for (LivingEntity e : world.getEntitiesOfClass(LivingEntity.class, new AABB(livingEntity.position().add(range, range, range), livingEntity.position().subtract(range, range, range)))) {
-            if (e.equals(livingEntity) || e.equals(shooter))
+            if (e.equals(livingEntity) || (!CASTER_AFFECTED.get() && e.equals(shooter)))
                 continue;
             if (canDamage(e)) {
                 vec = e.position();
@@ -80,6 +80,7 @@ public class EffectColdSnap extends AbstractEffect implements IDamageEffect {
         addAmpConfig(builder, 2.5);
         addPotionConfig(builder, 5);
         addExtendTimeConfig(builder, 1);
+	addCasterAffectedConfig(builder, false);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectExplosion.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectExplosion.java
@@ -41,7 +41,7 @@ public class EffectExplosion extends AbstractEffect implements IDamageEffect {
         intensity -= 0.5 * dampen;
         Explosion.BlockInteraction mode = dampen > 0 ? Explosion.BlockInteraction.NONE : Explosion.BlockInteraction.DESTROY;
         mode = spellStats.hasBuff(AugmentExtract.INSTANCE) ? Explosion.BlockInteraction.BREAK : mode;
-        explode(world, shooter, null, null, vec.x, vec.y, vec.z, (float) intensity, false, mode, spellStats.getAmpMultiplier());
+        explode(world, CASTER_AFFECTED.get() ? null : shooter, null, null, vec.x, vec.y, vec.z, (float) intensity, false, mode, spellStats.getAmpMultiplier());
     }
 
     public Explosion explode(Level world, @Nullable Entity e, @Nullable DamageSource source, @Nullable ExplosionDamageCalculator context,
@@ -73,6 +73,7 @@ public class EffectExplosion extends AbstractEffect implements IDamageEffect {
     public void buildConfig(ForgeConfigSpec.Builder builder) {
         super.buildConfig(builder);
         addAmpConfig(builder, 0.5);
+	addCasterAffectedConfig(builder, false);
         BASE = builder.comment("Explosion base intensity").defineInRange("base", 0.75, 0.0, 100);
         AOE_BONUS = builder.comment("AOE intensity bonus").defineInRange("aoe_bonus", 1.5, 0.0, 100);
         addDamageConfig(builder, 6.0);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFlare.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectFlare.java
@@ -41,7 +41,7 @@ public class EffectFlare extends AbstractEffect implements IDamageEffect {
             dealDamage(world, shooter, damage, spellStats, livingEntity, source);
             ((ServerLevel) world).sendParticles(ParticleTypes.FLAME, vec.x, vec.y + 0.5, vec.z, 50,
                     ParticleUtil.inRange(-0.1, 0.1), ParticleUtil.inRange(-0.1, 0.1), ParticleUtil.inRange(-0.1, 0.1), 0.3);
-            for (Entity e : world.getEntities(shooter, new AABB(
+            for (Entity e : world.getEntities(CASTER_AFFECTED.get() ? null : shooter, new AABB(
                     livingEntity.position().add(range, range, range), livingEntity.position().subtract(range, range, range)))) {
                 if (e.equals(livingEntity) || !(e instanceof LivingEntity))
                     continue;
@@ -65,6 +65,7 @@ public class EffectFlare extends AbstractEffect implements IDamageEffect {
         addDamageConfig(builder, 7.0);
         addAmpConfig(builder, 3.0);
         addExtendTimeConfig(builder, 1);
+	addCasterAffectedConfig(builder, false);
     }
 
     @Override


### PR DESCRIPTION
I was having fun accidentally killing my friends with a souped-up flare, but i felt bad that I couldn't accidentally blast myself with it. This PR adds config options to flare, cold snap, and explosion to allow them to affect the caster.