### PR TITLE
Make it work with GeckoLib 103

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ repositories {
 }
 dependencies {
 
-    minecraft 'net.minecraftforge:forge:1.16.5-36.2.4'
+    minecraft 'net.minecraftforge:forge:1.16.5-36.2.39'
     runtimeOnly fg.deobf("curse.maven:exp-406201:3419814") //Blame
     runtimeOnly fg.deobf("curse.maven:exp-248787:3395800")  // Appleskin
     runtimeOnly fg.deobf("curse.maven:exp-407174:3188120")  // Shutup experimental settings
@@ -160,7 +160,7 @@ dependencies {
 //    runtimeOnly fg.deobf("curse.maven:exp-449945:3429057")  // Per viam invenire
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.16.3-4.0.1.0:api")
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.16.3-4.0.1.0")
-    implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.16.5:3.0.64')
+    implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.16.5:3.0.103')
     
     compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.4:7.1.0.84")
     runtimeOnly fg.deobf("curse.maven:exp-74072:3695126") //Tinkers construct

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/ModelLayerRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/ModelLayerRenderer.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class ModelLayerRenderer<T extends Entity & IAnimatable> extends GeoLayerRenderer implements IGeoRenderer<T> {
     AnimatedGeoModel geoModelProvider;
+    public IRenderTypeBuffer rtb;
     private static Map<Class<? extends ArmorItem>, GeoArmorRenderer> renderers = new ConcurrentHashMap<>();
 
     static
@@ -45,6 +46,16 @@ public class ModelLayerRenderer<T extends Entity & IAnimatable> extends GeoLayer
     public ModelLayerRenderer(IGeoRenderer<T> entityRendererIn, AnimatedGeoModel modelProvider) {
         super(entityRendererIn);
         this.geoModelProvider = modelProvider;
+    }
+
+    @Override
+    public void setCurrentRTB(IRenderTypeBuffer rtb) {
+        this.rtb = rtb;
+    }
+
+    @Override
+    public IRenderTypeBuffer getCurrentRTB() {
+        return this.rtb;
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/potions/ModPotions.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/potions/ModPotions.java
@@ -23,19 +23,19 @@ import java.util.ArrayList;
 @ObjectHolder(ArsNouveau.MODID)
 public class ModPotions {
 
-    public static final ShieldEffect SHIELD_POTION = new ShieldEffect();
-    public static final ShockedEffect SHOCKED_EFFECT = new ShockedEffect();
-    public static final ManaRegenEffect MANA_REGEN_EFFECT = new ManaRegenEffect();
-    public static final SummoningSicknessEffect SUMMONING_SICKNESS = new SummoningSicknessEffect();
-    public static final HexEffect HEX_EFFECT = new HexEffect();
-    public static final ScryingEffect SCRYING_EFFECT = new ScryingEffect();
-    public static final GlideEffect GLIDE_EFFECT = new GlideEffect();
-    public static final SnareEffect SNARE_EFFECT = new SnareEffect();
-    public static final FlightEffect FLIGHT_EFFECT = new FlightEffect();
-    public static final GravityEffect GRAVITY_EFFECT = new GravityEffect();
+    public static final Effect SHIELD_POTION = new ShieldEffect();
+    public static final Effect SHOCKED_EFFECT = new ShockedEffect();
+    public static final Effect MANA_REGEN_EFFECT = new ManaRegenEffect();
+    public static final Effect SUMMONING_SICKNESS = new SummoningSicknessEffect();
+    public static final Effect HEX_EFFECT = new HexEffect();
+    public static final Effect SCRYING_EFFECT = new ScryingEffect();
+    public static final Effect GLIDE_EFFECT = new GlideEffect();
+    public static final Effect SNARE_EFFECT = new SnareEffect();
+    public static final Effect FLIGHT_EFFECT = new FlightEffect();
+    public static final Effect GRAVITY_EFFECT = new GravityEffect();
     public static final Effect SPELL_DAMAGE_EFFECT = new PublicEffect(EffectType.BENEFICIAL, new ParticleColor(30, 200, 200).getColor()).setRegistryName(ArsNouveau.MODID, LibPotions.SPELL_DAMAGE);
     public static final Effect FAMILIAR_SICKNESS_EFFECT = new PublicEffect(EffectType.NEUTRAL, new ParticleColor(30, 200, 200).getColor(), new ArrayList<>()).setRegistryName(ArsNouveau.MODID, LibPotions.FAMILIAR_SICKNESS);
-    public static final BounceEffect BOUNCE_EFFECT = new BounceEffect();
+    public static final Effect BOUNCE_EFFECT = new BounceEffect();
     @ObjectHolder(LibPotions.MANA_REGEN) public static Potion MANA_REGEN_POTION;
     @ObjectHolder(LibPotions.MANA_REGEN_LONG) public static Potion LONG_MANA_REGEN_POTION;
     @ObjectHolder(LibPotions.MANA_REGEN_STRONG) public static Potion STRONG_MANA_REGEN_POTION;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -59,6 +59,6 @@ Craft spells, create powerful baubles, and summon magical creatures!
 [[dependencies.ars_nouveau]]
     modId="geckolib3"
     mandatory=true
-    versionRange="[3.0.64,3.0.96]"
+    versionRange="[3.0.103,)"
     ordering="AFTER"
     side="BOTH"


### PR DESCRIPTION
Since several modpacks need to move forward, I quickly fixed Ars Nouveau 1.16.5 to work with Geckolib 103.

Validated with people over at Roguelike Adventures and Dungeons 2

Would be great if you could release this.