### PR TITLE
Split Creative Tab, making one just for Glyphs

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/ArsNouveau.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/ArsNouveau.java
@@ -4,18 +4,22 @@ import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.ritual.DispenserRitualBehavior;
 import com.hollingsworth.arsnouveau.client.events.ClientHandler;
 import com.hollingsworth.arsnouveau.client.events.TextureEvent;
+import com.hollingsworth.arsnouveau.client.gui.book.BaseBook;
 import com.hollingsworth.arsnouveau.common.advancement.ANCriteriaTriggers;
 import com.hollingsworth.arsnouveau.common.entity.ModEntities;
 import com.hollingsworth.arsnouveau.common.entity.pathfinding.ClientEventHandler;
 import com.hollingsworth.arsnouveau.common.entity.pathfinding.FMLEventHandler;
 import com.hollingsworth.arsnouveau.common.entity.pathfinding.Pathfinding;
+import com.hollingsworth.arsnouveau.common.items.Glyph;
 import com.hollingsworth.arsnouveau.common.items.RitualTablet;
 import com.hollingsworth.arsnouveau.common.network.Networking;
 import com.hollingsworth.arsnouveau.common.potions.ModPotions;
+import com.hollingsworth.arsnouveau.common.spell.method.MethodProjectile;
 import com.hollingsworth.arsnouveau.common.world.Terrablender;
 import com.hollingsworth.arsnouveau.setup.*;
 import com.hollingsworth.arsnouveau.setup.config.ANModConfig;
 import com.hollingsworth.arsnouveau.setup.config.ServerConfig;
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.ComposterBlock;
@@ -37,7 +41,6 @@ import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 
-
 @Mod(ArsNouveau.MODID)
 @Mod.EventBusSubscriber(modid = ArsNouveau.MODID)
 public class ArsNouveau {
@@ -51,6 +54,25 @@ public class ArsNouveau {
         @Override
         public ItemStack makeIcon() {
             return ItemsRegistry.CREATIVE_SPELLBOOK.get().getDefaultInstance();
+        }
+    };
+    public static CreativeModeTab glyphGroup = new CreativeModeTab(CreativeModeTab.getGroupCountSafe(), "ars_glyphs") {
+
+        @Override
+        public void fillItemList(NonNullList<ItemStack> pItems) {
+            super.fillItemList(pItems);
+            pItems.sort((ItemStack i1, ItemStack i2) -> {
+                if (i1.getItem() instanceof Glyph g1 && i2.getItem() instanceof Glyph g2) {
+                    return BaseBook.COMPARE_TYPE_THEN_NAME.compare(g1.spellPart, g2.spellPart);
+                } else {
+                    return -1;
+                }
+            });
+        }
+
+        @Override
+        public ItemStack makeIcon() {
+            return ArsNouveauAPI.getInstance().getGlyphItem(MethodProjectile.INSTANCE).getDefaultInstance();
         }
     };
 

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractAugment.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractAugment.java
@@ -16,6 +16,10 @@ public abstract class AbstractAugment extends AbstractSpellPart implements ISpel
         super(tag, description);
     }
 
+    @Override
+    public Integer getTypeIndex() {
+        return 5;
+    }
 
    @NotNull
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCastMethod.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCastMethod.java
@@ -23,6 +23,11 @@ public abstract class AbstractCastMethod extends AbstractSpellPart {
         super(tag, description);
     }
 
+    @Override
+    public Integer getTypeIndex() {
+        return 1;
+    }
+
 
     /**
      * Called when the spell is cast on nothing. In context of items, this is called when the player right clicks air.

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
@@ -53,7 +53,12 @@ public abstract class AbstractEffect extends AbstractSpellPart {
         super(tag, description);
     }
 
-    public void onResolve(HitResult rayTraceResult, Level world,@NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+    @Override
+    public Integer getTypeIndex() {
+        return 10;
+    }
+
+    public void onResolve(HitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         if (rayTraceResult instanceof BlockHitResult blockHitResult) {
             onResolveBlock(blockHitResult, world, shooter, spellStats, spellContext, resolver);
         } else if (rayTraceResult instanceof EntityHitResult entityHitResult) {

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
@@ -21,6 +21,11 @@ public abstract class AbstractSpellPart implements Comparable<AbstractSpellPart>
     public String name;
     public Glyph glyphItem;
 
+    /**
+     * Used for item tab ordering
+     */
+    public abstract Integer getTypeIndex();
+
     /*ID for NBT data and SpellManager#spellList*/
     public ResourceLocation getRegistryName() {
         return this.registryName;

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/BaseBook.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/BaseBook.java
@@ -2,8 +2,6 @@ package com.hollingsworth.arsnouveau.client.gui.book;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
 import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
-import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
-import com.hollingsworth.arsnouveau.api.spell.AbstractCastMethod;
 import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
 import com.hollingsworth.arsnouveau.api.spell.SpellValidationError;
 import com.hollingsworth.arsnouveau.client.gui.BookSlider;
@@ -36,20 +34,7 @@ public class BaseBook extends ModdedScreen {
         itemre = this.itemRenderer;
     }
 
-    public static Comparator<AbstractSpellPart> COMPARE_GLYPH_BY_TYPE = new Comparator<AbstractSpellPart>() {
-        @Override
-        public int compare(AbstractSpellPart o1, AbstractSpellPart o2) {
-            return fromType(o1) - fromType(o2);
-        }
-
-        public int fromType(AbstractSpellPart spellPart) {
-            if (spellPart instanceof AbstractCastMethod)
-                return 1;
-            if (spellPart instanceof AbstractAugment)
-                return 2;
-            return 3;
-        }
-    };
+    public static Comparator<AbstractSpellPart> COMPARE_GLYPH_BY_TYPE = Comparator.comparingInt(AbstractSpellPart::getTypeIndex);
 
     public static Comparator<AbstractSpellPart> COMPARE_TYPE_THEN_NAME = COMPARE_GLYPH_BY_TYPE.thenComparing(AbstractSpellPart::getLocaleName);
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/Glyph.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/Glyph.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.common.items;
 
+import com.hollingsworth.arsnouveau.ArsNouveau;
 import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
 import com.hollingsworth.arsnouveau.api.spell.SpellSchool;
@@ -14,6 +15,7 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
@@ -27,7 +29,7 @@ public class Glyph extends ModItem {
     public AbstractSpellPart spellPart;
 
     public Glyph(AbstractSpellPart part) {
-        super();
+        super(new Item.Properties().tab(ArsNouveau.glyphGroup));
         this.spellPart = part;
     }
 

--- a/src/main/resources/assets/ars_nouveau/lang/en_us.json
+++ b/src/main/resources/assets/ars_nouveau/lang/en_us.json
@@ -236,6 +236,7 @@
   "key.ars_nouveau.open_book": "(Spell Book) Open Book",
   "key.ars_nouveau.selection_hud": "Toggle Selection HUD",
   "itemGroup.ars_nouveau": "Ars Nouveau",
+  "itemGroup.ars_glyphs": "Ars Nouveau Glyphs",
   "item.ars_nouveau.novice_spell_book": "Novice Spell Book",
   "item.ars_nouveau.apprentice_spell_book": "Mage's Spell Book",
   "item.ars_nouveau.archmage_spell_book": "Archmage Spell Book",

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "Ars Nouveau Resources",
-        "pack_format": 9,
+        "pack_format": 10,
         "_comment": ""
     }
 }


### PR DESCRIPTION
The item ordering of the creative tab will follow the book's.
Added an index in AbstractSpellPart to use for ordering instead of using hardcoded classification in COMPARE_GLYPH_BY_TYPE, allowing addons to give a specific order to their effects.
Default values:
1 for Methods
5 for Augments
10 for Effects

