### PR TITLE
feat: add WAILA plugin for mirrorweave blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,7 @@ dependencies {
 //    implementation fg.deobf("curse.maven:ars_elemental-561470:4077798") // ars elemental
     implementation fg.deobf("curse.maven:cyanide-541676:3832812") // Cyanide
     compileOnly fg.deobf("top.theillusivec4.caelus:caelus-forge:${mc_version}-3.0.0.3:api")
+    implementation fg.deobf("curse.maven:jade-324717:4318618")
     runtimeOnly fg.deobf("curse.maven:config-457570:4011355")
 //    implementation fg.deobf("com.simibubi.create:create-1.19.2:0.5.0.f-15:slim"){ transitive = false }
 //    implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-1.19.2:0.6.7-9")

--- a/src/main/java/com/hollingsworth/arsnouveau/client/waila/WailaArsNouveauPlugin.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/waila/WailaArsNouveauPlugin.java
@@ -1,0 +1,33 @@
+package com.hollingsworth.arsnouveau.client.waila;
+
+import com.hollingsworth.arsnouveau.common.block.tile.GhostWeaveTile;
+import com.hollingsworth.arsnouveau.common.block.tile.MirrorWeaveTile;
+import com.hollingsworth.arsnouveau.common.potions.ModPotions;
+import net.minecraft.world.entity.player.Player;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.IWailaPlugin;
+import snownee.jade.api.WailaPlugin;
+
+@WailaPlugin
+public class WailaArsNouveauPlugin implements IWailaPlugin {
+    @Override
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.addRayTraceCallback((hitResult, accessor, originalAccessor) -> {
+            if (accessor instanceof BlockAccessor target) {
+                Player player = accessor.getPlayer();
+                if (player.isCreative() || player.isSpectator() || player.hasEffect(ModPotions.MAGIC_FIND_EFFECT.get()))
+                    return accessor;
+
+                if (target.getBlockEntity() instanceof GhostWeaveTile tile && tile.isInvisible()) {
+                    return null;
+                }
+
+                if (target.getBlockEntity() instanceof MirrorWeaveTile tile) {
+                    return registration.blockAccessor().from(target).blockState(tile.mimicState).build();
+                }
+            }
+            return accessor;
+        });
+    }
+}


### PR DESCRIPTION
Behaviour explanation:
If in creative, spectator or have MAGIC_FIND_EFFECT, display blocks normally.
If block is ghostweave and it's invisible, display nothing.
If block is any type of mirror weave, display the mimic block.