### PR TITLE
feat: create getters for displaying in spellbook and unlock menu

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
@@ -152,6 +152,18 @@ public abstract class AbstractSpellPart implements Comparable<AbstractSpellPart>
         GLYPH_TIER = builder.comment("The tier of the glyph").defineInRange("glyph_tier", defaultTier().value, 1, 99);
     }
 
+    public boolean shouldShowInUnlock() {
+        return isEnabled();
+    }
+
+    public boolean shouldShowInSpellBook() {
+        return isEnabled();
+    }
+
+    public boolean isEnabled() {
+        return ENABLED == null || ENABLED.get();
+    }
+
     /**
      * Returns the number of times that this glyph may be modified by the given augment.
      */

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GlyphUnlockMenu.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GlyphUnlockMenu.java
@@ -70,7 +70,7 @@ public class GlyphUnlockMenu extends BaseBook {
 
     public GlyphUnlockMenu(BlockPos pos) {
         super();
-        allParts = new ArrayList<>(ArsNouveauAPI.getInstance().getSpellpartMap().values());
+        allParts = new ArrayList<>(ArsNouveauAPI.getInstance().getSpellpartMap().values().stream().filter(AbstractSpellPart::shouldShowInUnlock).toList());
         this.displayedGlyphs = new ArrayList<>(allParts);
         this.scribesPos = pos;
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GuiSpellBook.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GuiSpellBook.java
@@ -79,7 +79,7 @@ public class GuiSpellBook extends BaseBook {
         this.hand = hand;
         IPlayerCap cap = CapabilityRegistry.getPlayerDataCap(Minecraft.getInstance().player).orElse(null);
         ItemStack heldStack = Minecraft.getInstance().player.getItemInHand(hand);
-        List<AbstractSpellPart> parts = cap == null ? new ArrayList<>() : new ArrayList<>(cap.getKnownGlyphs());
+        List<AbstractSpellPart> parts = cap == null ? new ArrayList<>() : new ArrayList<>(cap.getKnownGlyphs().stream().filter(AbstractSpellPart::shouldShowInSpellBook).toList());
         parts.addAll(api.getDefaultStartingSpells());
         if (heldStack.getItem() == ItemsRegistry.CREATIVE_SPELLBOOK.get())
             parts = new ArrayList<>(ArsNouveauAPI.getInstance().getSpellpartMap().values());

--- a/src/main/java/com/hollingsworth/arsnouveau/setup/Config.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/setup/Config.java
@@ -70,7 +70,7 @@ public class Config {
             throw new IllegalArgumentException("Spell Part with id " + tag + " does not exist in registry. Did you pass the right ID?");
         }
 
-        return spellPart.ENABLED == null || spellPart.ENABLED.get();
+        return spellPart.isEnabled();
     }
 
     public static boolean isGlyphEnabled(AbstractSpellPart tag) {


### PR DESCRIPTION
This will hide disabled glyphs from being used inside the spellbook or shown in the unlock menu, it also enables the capability for glyphs to be implemented that aren't shown inside either of those places.