### PR TITLE
fix: add default behavior dispatch fallback

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/mob_jar/JarBehaviorRegistry.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/mob_jar/JarBehaviorRegistry.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 public class JarBehaviorRegistry {
-
+    public static final List<JarBehavior<?>> DEFAULT_BEHAVIOR = List.of(new JarBehavior<>());
     private static final ConcurrentHashMap<EntityType<?>, List<JarBehavior<?>>> BEHAVIOR_REGISTRY = new ConcurrentHashMap<>();
 
     public static <T extends Entity> void register(EntityType<T> type, JarBehavior<T> jarBehavior) {
@@ -20,7 +20,7 @@ public class JarBehaviorRegistry {
     }
 
     public static void forEach(Entity entity, Consumer<JarBehavior<? extends Entity>> consumer){
-        List<JarBehavior<?>> jarBehaviors = BEHAVIOR_REGISTRY.getOrDefault(entity.getType(), new ArrayList<>());
+        List<JarBehavior<?>> jarBehaviors = BEHAVIOR_REGISTRY.getOrDefault(entity.getType(), DEFAULT_BEHAVIOR);
         for(JarBehavior<?> jarBehavior : jarBehaviors){
             consumer.accept(jarBehavior);
         }


### PR DESCRIPTION
Fixes comparators not providing a signal when a mob jar behaviour hasn't been registered for the specific entity.

Falls back to call the method on the default mob jar behaviour when no specific behaviour has been registered.