### PR TITLE
fix: add entity checks to prevent mob jar riding crashing on Nether load

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/event/JarEvents.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/event/JarEvents.java
@@ -7,7 +7,9 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LightningBolt;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.level.NoteBlockEvent;
@@ -39,9 +41,13 @@ public class JarEvents {
 
     @SubscribeEvent
     public static void onRide(EntityMountEvent mountEvent){
-//        Entity beingMounted = mountEvent.getEntityBeingMounted();
-//        if (beingMounted.getLevel().isLoaded(beingMounted.getOnPos()) && beingMounted.getLevel().getBlockEntity(beingMounted.getOnPos()) instanceof MobJarTile) {
-//            mountEvent.setCanceled(true);
-//        }
+        if (mountEvent.isDismounting()) return;
+        if (mountEvent.getLevel().isClientSide) return;
+        if (mountEvent.getEntityMounting() instanceof Player) {
+            Entity beingMounted = mountEvent.getEntityBeingMounted();
+            if (mountEvent.getLevel().isLoaded(beingMounted.getOnPos()) && mountEvent.getLevel().getBlockEntity(beingMounted.getOnPos()) instanceof MobJarTile) {
+                mountEvent.setCanceled(true);
+            }
+        }
     }
 }


### PR DESCRIPTION
This should fix the issues with the startRiding event, I checked loading in while in a boat, as well as loading the Nether, everything works as expected, may be worth doing some additional checks if you can think of anything before merge