### PR TITLE
fix: remove pillagers in jars from raids

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualMobCapture.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualMobCapture.java
@@ -16,7 +16,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.raid.Raid;
 import net.minecraft.world.entity.raid.Raider;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualMobCapture.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualMobCapture.java
@@ -16,6 +16,8 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.raid.Raid;
+import net.minecraft.world.entity.raid.Raider;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
@@ -47,6 +49,9 @@ public class RitualMobCapture extends AbstractRitual {
                             if(mob.isLeashed()){
                                 mob.dropLeash(true, true);
                             }
+                        }
+                        if (e instanceof Raider raider && raider.hasActiveRaid()) {
+                            raider.getCurrentRaid().removeFromRaid(raider, false);
                         }
                         if(tile.setEntityData(e)){
                             e.remove(Entity.RemovalReason.UNLOADED_TO_CHUNK);


### PR DESCRIPTION
Remove raiders from their active raid when capturing them