### PR TITLE
fix: add ars geo renderer

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/AgronomicRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/AgronomicRenderer.java
@@ -3,9 +3,8 @@ package com.hollingsworth.arsnouveau.client.renderer.tile;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRenderer;
 import com.hollingsworth.arsnouveau.common.block.tile.AgronomicSourcelinkTile;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class AgronomicRenderer extends GeoBlockRenderer<AgronomicSourcelinkTile> {
+public class AgronomicRenderer extends ArsGeoBlockRenderer<AgronomicSourcelinkTile> {
     public static SourcelinkModel model = new SourcelinkModel("agronomic");
 
     public AgronomicRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/AlchemicalRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/AlchemicalRenderer.java
@@ -3,9 +3,8 @@ package com.hollingsworth.arsnouveau.client.renderer.tile;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRenderer;
 import com.hollingsworth.arsnouveau.common.block.tile.AlchemicalSourcelinkTile;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class AlchemicalRenderer extends GeoBlockRenderer<AlchemicalSourcelinkTile> {
+public class AlchemicalRenderer extends ArsGeoBlockRenderer<AlchemicalSourcelinkTile> {
 
     public static SourcelinkModel model = new SourcelinkModel<>("alchemical");
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/AlterationTableRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/AlterationTableRenderer.java
@@ -39,14 +39,13 @@ import net.minecraft.world.level.levelgen.synth.PerlinSimplexNoise;
 import net.minecraftforge.client.ForgeHooksClient;
 import software.bernie.geckolib3.geo.render.built.GeoBone;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 import software.bernie.geckolib3.util.RenderUtils;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
-public class AlterationTableRenderer extends GeoBlockRenderer<AlterationTile> {
+public class AlterationTableRenderer extends ArsGeoBlockRenderer<AlterationTile> {
     private static final Map<String, ResourceLocation> ARMOR_LOCATION_CACHE = Maps.newHashMap();
 
     public final ArmorStandArmorModel innerModel;

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ArcaneCoreRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ArcaneCoreRenderer.java
@@ -4,9 +4,8 @@ import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRendere
 import com.hollingsworth.arsnouveau.common.block.tile.ArcaneCoreTile;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class ArcaneCoreRenderer extends GeoBlockRenderer<ArcaneCoreTile> {
+public class ArcaneCoreRenderer extends ArsGeoBlockRenderer<ArcaneCoreTile> {
     public static AnimatedGeoModel model = new GenericModel("arcane_core");
 
     public ArcaneCoreRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ArsGeoBlockRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ArsGeoBlockRenderer.java
@@ -1,0 +1,21 @@
+package com.hollingsworth.arsnouveau.client.renderer.tile;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import software.bernie.geckolib3.core.IAnimatable;
+import software.bernie.geckolib3.model.AnimatedGeoModel;
+import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
+
+public abstract class ArsGeoBlockRenderer<T extends BlockEntity & IAnimatable> extends GeoBlockRenderer<T> {
+    public ArsGeoBlockRenderer(BlockEntityRendererProvider.Context rendererProvider, AnimatedGeoModel<T> modelProvider) {
+        super(rendererProvider, modelProvider);
+    }
+
+    @Override
+    public void render(T tile, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight) {
+        poseStack.translate(0, -0.01f, 0);
+        super.render(tile, partialTick, poseStack, bufferSource, packedLight);
+    }
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/BasicTurretRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/BasicTurretRenderer.java
@@ -11,11 +11,10 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.core.Direction;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
 import javax.annotation.Nullable;
 
-public class BasicTurretRenderer extends GeoBlockRenderer<BasicSpellTurretTile> {
+public class BasicTurretRenderer extends ArsGeoBlockRenderer<BasicSpellTurretTile> {
     public static AnimatedGeoModel model = new GenericModel("basic_spell_turret");
 
     public BasicTurretRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/EnchantingApparatusRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/EnchantingApparatusRenderer.java
@@ -14,10 +14,9 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import software.bernie.geckolib3.geo.render.built.GeoBone;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 import software.bernie.geckolib3.util.RenderUtils;
 
-public class EnchantingApparatusRenderer extends GeoBlockRenderer<EnchantingApparatusTile> {
+public class EnchantingApparatusRenderer extends ArsGeoBlockRenderer<EnchantingApparatusTile> {
 
     public EnchantingApparatusRenderer(BlockEntityRendererProvider.Context p_i226006_1_) {
         super(p_i226006_1_, new GenericModel<>("enchanting_apparatus"));

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/GenericRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/GenericRenderer.java
@@ -3,11 +3,10 @@ package com.hollingsworth.arsnouveau.client.renderer.tile;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRenderer;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
 import java.util.function.Supplier;
 
-public class GenericRenderer extends GeoBlockRenderer {
+public class GenericRenderer extends ArsGeoBlockRenderer {
 
     public static GenericModel model = new GenericModel("source_relay");
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ImbuementRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ImbuementRenderer.java
@@ -11,9 +11,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class ImbuementRenderer extends GeoBlockRenderer<ImbuementTile> {
+public class ImbuementRenderer extends ArsGeoBlockRenderer<ImbuementTile> {
 
     public ImbuementRenderer(BlockEntityRendererProvider.Context p_i226006_1_) {
         super(p_i226006_1_, new GenericModel<>("imbuement_chamber"));

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/LecternRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/LecternRenderer.java
@@ -4,9 +4,8 @@ import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRendere
 import com.hollingsworth.arsnouveau.common.block.tile.CraftingLecternTile;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class LecternRenderer extends GeoBlockRenderer<CraftingLecternTile> {
+public class LecternRenderer extends ArsGeoBlockRenderer<CraftingLecternTile> {
     public static AnimatedGeoModel model = new GenericModel<>("book_wyrm_lectern");
 
     public LecternRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/MycelialRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/MycelialRenderer.java
@@ -3,9 +3,8 @@ package com.hollingsworth.arsnouveau.client.renderer.tile;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRenderer;
 import com.hollingsworth.arsnouveau.common.block.tile.MycelialSourcelinkTile;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class MycelialRenderer extends GeoBlockRenderer<MycelialSourcelinkTile> {
+public class MycelialRenderer extends ArsGeoBlockRenderer<MycelialSourcelinkTile> {
     public static SourcelinkModel model = new SourcelinkModel("mycelial");
 
     public MycelialRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/PotionMelderRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/PotionMelderRenderer.java
@@ -3,9 +3,8 @@ package com.hollingsworth.arsnouveau.client.renderer.tile;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRenderer;
 import com.hollingsworth.arsnouveau.common.block.tile.PotionMelderTile;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class PotionMelderRenderer extends GeoBlockRenderer<PotionMelderTile> {
+public class PotionMelderRenderer extends ArsGeoBlockRenderer<PotionMelderTile> {
 
     public PotionMelderRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {
         super(rendererDispatcherIn, new PotionMelderModel());

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/RepositoryRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/RepositoryRenderer.java
@@ -15,10 +15,9 @@ import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib3.core.util.Color;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 import software.bernie.geckolib3.util.EModelRenderCycle;
 
-public class RepositoryRenderer extends GeoBlockRenderer<RepositoryTile> {
+public class RepositoryRenderer extends ArsGeoBlockRenderer<RepositoryTile> {
     public static AnimatedGeoModel<RepositoryTile> model = new RepositoryModel();
     public RepositoryRenderer(BlockEntityRendererProvider.Context rendererProvider) {
         super(rendererProvider, model);

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/RotatingTurretRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/RotatingTurretRenderer.java
@@ -8,10 +8,9 @@ import net.minecraft.util.Mth;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.processor.IBone;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
 @SuppressWarnings("rawtypes")
-public class RotatingTurretRenderer extends GeoBlockRenderer<RotatingTurretTile> {
+public class RotatingTurretRenderer extends ArsGeoBlockRenderer<RotatingTurretTile> {
     public static AnimatedGeoModel model = new GenericModel("basic_spell_turret") {
         @Override
         public void setCustomAnimations(Object animatable, int instanceId, AnimationEvent event) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/RuneRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/RuneRenderer.java
@@ -9,11 +9,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
 import javax.annotation.Nullable;
 
-public class RuneRenderer extends GeoBlockRenderer<RuneTile> {
+public class RuneRenderer extends ArsGeoBlockRenderer<RuneTile> {
 
     public static GenericModel model = new GenericModel("rune");
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ScribesRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ScribesRenderer.java
@@ -25,12 +25,11 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class ScribesRenderer extends GeoBlockRenderer<ScribesTile> {
+public class ScribesRenderer extends ArsGeoBlockRenderer<ScribesTile> {
     public static AnimatedGeoModel model = new GenericModel<>("scribes_table");
 
     public ScribesRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ScryerEyeRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/ScryerEyeRenderer.java
@@ -10,9 +10,8 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class ScryerEyeRenderer extends GeoBlockRenderer<ScryersOculusTile> {
+public class ScryerEyeRenderer extends ArsGeoBlockRenderer<ScryersOculusTile> {
     ScryersEyeModel model;
 
     public ScryerEyeRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn, ScryersEyeModel model) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/VitalicRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/VitalicRenderer.java
@@ -3,9 +3,8 @@ package com.hollingsworth.arsnouveau.client.renderer.tile;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRenderer;
 import com.hollingsworth.arsnouveau.common.block.tile.VitalicSourcelinkTile;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class VitalicRenderer extends GeoBlockRenderer<VitalicSourcelinkTile> {
+public class VitalicRenderer extends ArsGeoBlockRenderer<VitalicSourcelinkTile> {
     public static SourcelinkModel model = new SourcelinkModel("vitalic");
 
     public VitalicRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/VolcanicRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/VolcanicRenderer.java
@@ -3,9 +3,8 @@ package com.hollingsworth.arsnouveau.client.renderer.tile;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRenderer;
 import com.hollingsworth.arsnouveau.common.block.tile.VolcanicSourcelinkTile;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
-public class VolcanicRenderer extends GeoBlockRenderer<VolcanicSourcelinkTile> {
+public class VolcanicRenderer extends ArsGeoBlockRenderer<VolcanicSourcelinkTile> {
     public static SourcelinkModel model = new SourcelinkModel("volcanic");
 
     public VolcanicRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/WhirlisprigFlowerRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/WhirlisprigFlowerRenderer.java
@@ -9,11 +9,10 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
-import software.bernie.geckolib3.renderers.geo.GeoBlockRenderer;
 
 import javax.annotation.Nullable;
 
-public class WhirlisprigFlowerRenderer extends GeoBlockRenderer<WhirlisprigTile> {
+public class WhirlisprigFlowerRenderer extends ArsGeoBlockRenderer<WhirlisprigTile> {
     public static AnimatedGeoModel model = new GenericModel("whirlisprig_blossom");
 
     public WhirlisprigFlowerRenderer(BlockEntityRendererProvider.Context rendererDispatcherIn) {


### PR DESCRIPTION
Adds `ArsGeoBlockRenderer` which translates the models by -0.01f, this fixes tile entities floating 0.1 pixels above the ground