### PR TITLE
fix: refactor to use stream with more guard statements

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/enchanting_apparatus/EnchantingApparatusRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/enchanting_apparatus/EnchantingApparatusRecipe.java
@@ -208,11 +208,7 @@ public class EnchantingApparatusRecipe implements IEnchantingRecipe {
                 Ingredient input = null;
                 JsonObject obj = item.getAsJsonObject();
                 if (GsonHelper.isObjectNode(obj, "item")) {
-                    if (GsonHelper.isArrayNode(obj, "item")) {
-                        input = Ingredient.fromJson(GsonHelper.getAsJsonArray(obj, "item"));
-                    } else {
-                        input = Ingredient.fromJson(GsonHelper.getAsJsonObject(obj, "item"));
-                    }
+                    input = Ingredient.fromJson(obj.get("item"));
                 } else {
                     input = Ingredient.fromJson(obj);
                 }


### PR DESCRIPTION
Tested with and allows the following formats:
```json
{
  "item": {
    "item": "minecraft:crafting_table"
  }
},
{
  "item": "minecraft:diamond_axe"
},
[
  {
    "item": "minecraft:lightning_rod"
  },
  {
    "item": "minecraft:stick"
  }
]
```