### PR TITLE
fix: validate parchment scribing (and fix compile issue, my bad)

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/enchanting_apparatus/EnchantingApparatusRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/enchanting_apparatus/EnchantingApparatusRecipe.java
@@ -220,7 +220,7 @@ public class EnchantingApparatusRecipe implements IEnchantingRecipe {
             int cost = json.has("sourceCost") ? GsonHelper.getAsInt(json, "sourceCost") : 0;
             boolean keepNbtOfReagent = json.has("keepNbtOfReagent") && GsonHelper.getAsBoolean(json, "keepNbtOfReagent");
             JsonArray pedestalItems = GsonHelper.getAsJsonArray(json, "pedestalItems");
-            List<Ingredient> stacks = getPedestalItems(ResourceLocation recipeId, pedestalItems);
+            List<Ingredient> stacks = getPedestalItems(recipeId, pedestalItems);
             return new EnchantingApparatusRecipe(recipeId, stacks, reagent, output, cost, keepNbtOfReagent);
         }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/BlankParchmentItem.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/BlankParchmentItem.java
@@ -1,7 +1,6 @@
 package com.hollingsworth.arsnouveau.common.items;
 
 import com.hollingsworth.arsnouveau.api.camera.ICameraMountable;
-import com.hollingsworth.arsnouveau.api.item.ICasterTool;
 import com.hollingsworth.arsnouveau.api.item.IScribeable;
 import com.hollingsworth.arsnouveau.common.block.tile.ScribesTile;
 import com.hollingsworth.arsnouveau.setup.ItemsRegistry;
@@ -43,14 +42,13 @@ public class BlankParchmentItem extends ModItem implements IScribeable {
 
     @Override
     public boolean onScribe(Level world, BlockPos pos, Player player, InteractionHand handIn, ItemStack thisStack) {
-        if(player.getItemInHand(handIn).getItem() instanceof ICasterTool casterTool){
-            if(world.getBlockEntity(pos) instanceof ScribesTile scribesTile){
-                scribesTile.setStack(new ItemStack(ItemsRegistry.SPELL_PARCHMENT.get()));
-                if(scribesTile.getStack().getItem() instanceof IScribeable iScribeable){
-                    iScribeable.onScribe(world, pos, player, handIn, scribesTile.getStack());
-                }
-                return true;
+        ItemStack spellParchment = new ItemStack(ItemsRegistry.SPELL_PARCHMENT.get());
+        if (spellParchment.getItem() instanceof IScribeable scribeable) {
+            boolean success = scribeable.onScribe(world, pos, player, handIn, spellParchment);
+            if (world.getBlockEntity(pos) instanceof ScribesTile scribesTile && success) {
+                scribesTile.setStack(spellParchment);
             }
+            return success;
         }
         return false;
     }


### PR DESCRIPTION
prevents spell parchment from being created without a valid spell