### PR TITLE
Invalid Combo configs

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractEffect.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -214,6 +215,7 @@ public abstract class AbstractEffect extends AbstractSpellPart {
     public void buildConfig(ForgeConfigSpec.Builder builder) {
         super.buildConfig(builder);
         super.buildAugmentLimitsConfig(builder, getDefaultAugmentLimits(new HashMap<>()));
+        super.buildInvalidCombosConfig(builder, getDefaultInvalidCombos(new HashSet<>()));
     }
 
     public void addDamageConfig(ForgeConfigSpec.Builder builder, double defaultValue) {

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractSpellPart.java
@@ -43,9 +43,9 @@ public abstract class AbstractSpellPart implements Comparable<AbstractSpellPart>
     public Set<AbstractAugment> compatibleAugments = ConcurrentHashMap.newKeySet();
 
     /**
-     * A list of glyphs that cannot be used with this glyph.
+     * A wrapper for the list of glyphs that cannot be used with this glyph. Parsed from configs.
      */
-    public Set<ResourceLocation> invalidCombinations = ConcurrentHashMap.newKeySet();
+    public SpellPartConfigUtil.ComboLimits invalidCombinations = new SpellPartConfigUtil.ComboLimits(null);
 
     public AbstractSpellPart(String registryName, String name) {
         this(new ResourceLocation(ArsNouveau.MODID, registryName), name);
@@ -186,6 +186,13 @@ public abstract class AbstractSpellPart implements Comparable<AbstractSpellPart>
     }
 
     /**
+     * Registers the glyph_limits configuration entry for combo limits.
+     */
+    protected void buildInvalidCombosConfig(ForgeConfigSpec.Builder builder, Set<ResourceLocation> defaults) {
+        this.invalidCombinations = SpellPartConfigUtil.buildInvalidCombosConfig(builder, defaults);
+    }
+
+    /**
      * Override this method to provide defaults for the augmentation limits configuration.
      */
     protected Map<ResourceLocation, Integer> getDefaultAugmentLimits(Map<ResourceLocation, Integer> defaults) {
@@ -194,6 +201,14 @@ public abstract class AbstractSpellPart implements Comparable<AbstractSpellPart>
     }
 
     protected void addDefaultAugmentLimits(Map<ResourceLocation, Integer> defaults) {}
+
+    protected Set<ResourceLocation> getDefaultInvalidCombos(Set<ResourceLocation> defaults) {
+        addDefaultInvalidCombos(defaults);
+        return defaults;
+    }
+
+    protected void addDefaultInvalidCombos(Set<ResourceLocation> defaults) {
+    }
 
     // Default value for the starter spell config
     public boolean defaultedStarterGlyph() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/lib/GlyphLib.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/lib/GlyphLib.java
@@ -86,6 +86,8 @@ public class GlyphLib {
     public static final String EffectRotateID = prependGlyph("rotate");
     public static final String EffectWallId = prependGlyph("wall");
 
+    public static final String EffectBurstID = prependGlyph("burst");
+
 
     public static String prependGlyph(String glyph) {
         return "glyph_" + glyph;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBurst.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBurst.java
@@ -7,6 +7,7 @@ import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentSensitive;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
@@ -21,12 +22,11 @@ import java.util.function.Predicate;
 
 public class EffectBurst extends AbstractEffect {
 
+    //TODO use GlyphLib#EffectBurstId
     public static final EffectBurst INSTANCE = new EffectBurst("burst", "Burst");
 
     public EffectBurst(String tag, String description) {
         super(tag, description);
-        invalidCombinations.add(EffectLinger.INSTANCE.getRegistryName());
-        invalidCombinations.add(EffectWall.INSTANCE.getRegistryName());
     }
 
     @Override
@@ -88,4 +88,9 @@ public class EffectBurst extends AbstractEffect {
         return augmentSetOf(AugmentAOE.INSTANCE, AugmentSensitive.INSTANCE, AugmentDampen.INSTANCE);
     }
 
+    @Override
+    protected void addDefaultInvalidCombos(Set<ResourceLocation> defaults) {
+        defaults.add(EffectLinger.INSTANCE.getRegistryName());
+        defaults.add(EffectWall.INSTANCE.getRegistryName());
+    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWall.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWall.java
@@ -5,6 +5,7 @@ import com.hollingsworth.arsnouveau.common.entity.EntityWallSpell;
 import com.hollingsworth.arsnouveau.common.lib.GlyphLib;
 import com.hollingsworth.arsnouveau.common.spell.augment.*;
 import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.HitResult;
@@ -22,7 +23,6 @@ public class EffectWall extends AbstractEffect {
 
     private EffectWall() {
         super(GlyphLib.EffectWallId, "Wall");
-        invalidCombinations.add(EffectLinger.INSTANCE.getRegistryName());
     }
 
     @Override
@@ -71,6 +71,11 @@ public class EffectWall extends AbstractEffect {
     @Override
     public Set<AbstractAugment> getCompatibleAugments() {
         return augmentSetOf(AugmentSensitive.INSTANCE, AugmentAOE.INSTANCE, AugmentAccelerate.INSTANCE, AugmentDecelerate.INSTANCE, AugmentExtendTime.INSTANCE, AugmentDurationDown.INSTANCE, AugmentDampen.INSTANCE);
+    }
+
+    @Override
+    protected void addDefaultInvalidCombos(Set<ResourceLocation> defaults) {
+        defaults.add(EffectLinger.INSTANCE.getRegistryName());
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/InvalidCombinationValidator.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/validation/InvalidCombinationValidator.java
@@ -23,7 +23,7 @@ public class InvalidCombinationValidator extends ScanningSpellValidator<Map<Reso
         } else {
             partCounts.put(spellPart.getRegistryName(), 1);
         }
-        for(ResourceLocation invalidPart : spellPart.invalidCombinations){
+        for (ResourceLocation invalidPart : spellPart.invalidCombinations.parseComboLimits()) {
             AbstractSpellPart offendingPart = ArsNouveauAPI.getInstance().getSpellPart(invalidPart);
             if(offendingPart == null)
                 continue;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/util/SpellPartConfigUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/util/SpellPartConfigUtil.java
@@ -4,8 +4,10 @@ import com.hollingsworth.arsnouveau.common.lib.GlyphLib;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.ForgeConfigSpec;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -29,7 +31,6 @@ public class SpellPartConfigUtil {
      * limitations.
      */
     public static class AugmentLimits {
-        private Map<ResourceLocation, Integer> limits = null;
         private ForgeConfigSpec.ConfigValue<List<? extends String>> configValue;
 
         /**
@@ -44,9 +45,10 @@ public class SpellPartConfigUtil {
          */
         public int getAugmentLimit(ResourceLocation augmentTag) {
             // No caching so /reload works
-            limits = parseAugmentLimits();
+            Map<ResourceLocation, Integer> limits = parseAugmentLimits();
             return limits.getOrDefault(augmentTag, Integer.MAX_VALUE);
         }
+
 
         /**
          * Parse glyph_limits into a Map from augment glyph tags to limits.
@@ -62,6 +64,35 @@ public class SpellPartConfigUtil {
         }
     }
 
+    public static class ComboLimits {
+        private final ForgeConfigSpec.ConfigValue<List<? extends String>> configValue;
+
+        /**
+         * Create a new AugmentLimits from the given ConfigValue
+         */
+        public ComboLimits(ForgeConfigSpec.ConfigValue<List<? extends String>> configValue) {
+            this.configValue = configValue;
+        }
+
+        public boolean contains(ResourceLocation glyphTag) {
+            return parseComboLimits().contains(glyphTag);
+        }
+
+
+        /**
+         * Parse glyph_limits into a Map from augment glyph tags to limits.
+         */
+        public Set<ResourceLocation> parseComboLimits() {
+            if (configValue == null) {
+                return new HashSet<>();
+            }
+            return configValue.get().stream()
+                    .map(ResourceLocation::tryParse)
+                    .collect(Collectors.toSet());
+        }
+    }
+
+
     /**
      * Builds a "augment_limits" configuration item using the provided {@link ForgeConfigSpec.Builder} and returns an
      * {@link AugmentLimits} instance to encapsulate it.
@@ -69,15 +100,32 @@ public class SpellPartConfigUtil {
     public static AugmentLimits buildAugmentLimitsConfig(ForgeConfigSpec.Builder builder, Map<ResourceLocation, Integer> defaults) {
         ForgeConfigSpec.ConfigValue<List<? extends String>> configValue = builder
                 .comment("Limits the number of times a given augment may be applied to a given effect", "Example entry: \"" + GlyphLib.AugmentAmplifyID + "=5\"")
-                .defineList("augment_limits", writeConfig(defaults), SpellPartConfigUtil::validateAugmentLimits);
+                .defineList("augment_limits", writeAugmentConfig(defaults), SpellPartConfigUtil::validateAugmentLimits);
 
         return new AugmentLimits(configValue);
+    }
+
+    public static ComboLimits buildInvalidCombosConfig(ForgeConfigSpec.Builder builder, Set<ResourceLocation> defaults) {
+        ForgeConfigSpec.ConfigValue<List<? extends String>> configValue = builder
+                .comment("Prevents the given glyph from being used in the same spell as the given glyph", "Example entry: \"" + GlyphLib.EffectBurstID + "\"")
+                .defineList("invalid_combos", writeComboConfig(defaults), (o) -> o instanceof String s && ResourceLocation.isValidResourceLocation(s));
+
+        return new ComboLimits(configValue);
+    }
+
+    /**
+     * Produces a list of resourcelocation strings suitable for saving to the configuration.
+     */
+    private static List<String> writeComboConfig(Set<ResourceLocation> augmentLimits) {
+        return augmentLimits.stream()
+                .map(ResourceLocation::toString)
+                .collect(Collectors.toList());
     }
 
     /**
      * Produces a list of tag=limit strings suitable for saving to the configuration.
      */
-    private static List<String> writeConfig(Map<ResourceLocation, Integer> augmentLimits) {
+    private static List<String> writeAugmentConfig(Map<ResourceLocation, Integer> augmentLimits) {
         return augmentLimits.entrySet().stream()
                 .map(e -> e.getKey().toString() + "=" + e.getValue().toString())
                 .collect(Collectors.toList());


### PR DESCRIPTION
While this is potentially a breaking change, no known addons seems to use the invalid combinations field, so it might be possible to safely merge this on both 1.19.2 and 1.20