### PR TITLE
fixes recursivly looped inventory lookup in relays by keeping track of traversed relays

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/BrazierRelayTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/BrazierRelayTile.java
@@ -15,12 +15,17 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.hollingsworth.arsnouveau.common.block.RitualBrazierBlock.LIT;
 
 public class BrazierRelayTile extends RitualBrazierTile{
 
     int ticksToLightOff = 0;
     public BlockPos brazierPos;
+
+    private static List<BlockPos> relayingTraversed = new ArrayList<>();
 
     public BrazierRelayTile(BlockEntityType<?> tileEntityTypeIn, BlockPos pos, BlockState state) {
         super(tileEntityTypeIn, pos, state);
@@ -111,12 +116,15 @@ public class BrazierRelayTile extends RitualBrazierTile{
 
     @Override
     public InventoryManager getInventoryManager() {
-        if (this.brazierPos != null && level != null && level.isLoaded(this.brazierPos) && level.getBlockEntity(this.brazierPos) instanceof RitualBrazierTile brazierTile) {
+        if (this.brazierPos != null && level != null && relayingTraversed.size() < 256 && !relayingTraversed.contains(brazierPos) && level.isLoaded(this.brazierPos) && level.getBlockEntity(this.brazierPos) instanceof RitualBrazierTile brazierTile) {
+            relayingTraversed.add(brazierPos);
             InventoryManager brazierInv = brazierTile.getInventoryManager();
-            if (brazierInv.getInventory().size() > 0) {
+            if (!brazierInv.getInventory().isEmpty()) {
+                relayingTraversed.clear();
                 return brazierInv;
             }
         }
+        relayingTraversed.clear();
         return super.getInventoryManager();
     }
 }


### PR DESCRIPTION
fixes: #1111
relays can be linked to other relays. When linked in a loop the crash happens. This tracks the traversed relays in the inventory lookup performed by the harvest ritual and cancels the search when a loop is detected or when no inventory has been found after 255 block searches. I'm not sure if relay linking is intended, but if it's not, I'll remove that too