### PR TITLE
Update greatly_likes.json

### DIFF
--- a/src/generated/resources/data/ars_nouveau/tags/blocks/whirlisprig/greatly_likes.json
+++ b/src/generated/resources/data/ars_nouveau/tags/blocks/whirlisprig/greatly_likes.json
@@ -5,6 +5,10 @@
     "minecraft:red_mushroom_block",
     "minecraft:shroomlight",
     "minecraft:warped_wart_block",
-    "minecraft:nether_wart_block"
+    "minecraft:nether_wart_block",
+    "minecraft:cactus",
+    "minecraft:sugar_cane",
+    "minecraft:chorus_flower",
+    "minecraft:chorus_plant"
   ]
 }


### PR DESCRIPTION
Added sylph harvest compatibility for cactus, sugar cane, and chorus fruit. Chorus has two lines so that the sylph can provide positive recognition to the flower, while harvesting both the plant (fruit) and flower (sapling).