### PR TITLE
Transparency cfg + Vex hotfixes

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/entity/ISummon.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/entity/ISummon.java
@@ -40,4 +40,12 @@ public interface ISummon extends OwnableEntity {
     default @Nullable Entity readOwner(ServerLevel world, CompoundTag tag) {
         return tag.contains("owner") ? world.getEntity(tag.getUUID("owner")) : null;
     }
+
+    /*
+     * This is a workaround for summon entities that inherit from an entity that override LivingEntity.getOwner() to return a subclass that doesn't include players. Ex. Vex
+     * By default it will redirect to the classic getOwner() method, so it's safer to use as getter for general purpose
+     * */
+    default LivingEntity getOwnerAlt() {
+        return getOwner();
+    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/utils/RenderUtils.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/utils/RenderUtils.java
@@ -2,6 +2,7 @@ package com.hollingsworth.arsnouveau.client.gui.utils;
 
 import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
 import com.hollingsworth.arsnouveau.client.gui.Color;
+import com.hollingsworth.arsnouveau.setup.config.Config;
 import com.mojang.blaze3d.platform.Lighting;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
@@ -65,7 +66,7 @@ public class RenderUtils {
                 ItemDisplayContext.GUI,
                 false,
                 poseStack,
-                transparent ? transparentBuffer(buffer) : buffer, // TODO: remove sodium check when sodium is fixed https://github.com/CaffeineMC/sodium-fabric/pull/1842/files
+                transparent && Config.GUI_TRANSPARENCY.get() ? transparentBuffer(buffer) : buffer, // TODO: remove sodium check when sodium is fixed https://github.com/CaffeineMC/sodium-fabric/pull/1842/files
                 LightTexture.FULL_BRIGHT,
                 OverlayTexture.NO_OVERLAY,
                 model

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/curios/SummoningFocus.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/curios/SummoningFocus.java
@@ -81,7 +81,7 @@ public class SummoningFocus extends ArsNouveauCurio implements ISpellModifierIte
         if (!event.getWorld().isClientSide && event.getEntity() instanceof Player && SummoningFocus.containsThis(event.getWorld(), event.getEntity())) {
             if (event.spell.getCastMethod() != null && sympatheticMethods.contains(event.spell.getCastMethod())) {
                 for (LivingEntity i : event.getWorld().getEntitiesOfClass(LivingEntity.class, new AABB(event.getEntity().blockPosition()).inflate(30), ISummon.class::isInstance)) {
-                    if (event.getEntity().equals(((ISummon) i).getOwner())) {
+                    if (event.getEntity().equals(((ISummon) i).getOwnerAlt())) {
                         EntitySpellResolver spellResolver = new EntitySpellResolver(event.context.clone().withWrappedCaster(new LivingCaster(i)));
                         spellResolver.onCast(ItemStack.EMPTY, i.level);
                     }
@@ -92,9 +92,9 @@ public class SummoningFocus extends ArsNouveauCurio implements ISpellModifierIte
 
     @SubscribeEvent
     public static void summonDeathEvent(SummonEvent.Death event) {
-        if (!event.world.isClientSide && SummoningFocus.containsThis(event.world, event.summon.getOwner())) {
+        if (!event.world.isClientSide && SummoningFocus.containsThis(event.world, event.summon.getOwnerAlt())) {
             DamageSource source = event.source;
-            if (source != null && source.getEntity() != null && source.getEntity() != event.summon.getOwner()) {
+            if (source != null && source.getEntity() != null && source.getEntity() != event.summon.getOwnerAlt()) {
                 source.getEntity().hurt(source.getEntity().level.damageSources().thorns(source.getEntity()), 5.0f);
             }
         }

--- a/src/main/java/com/hollingsworth/arsnouveau/setup/config/Config.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/setup/config/Config.java
@@ -66,6 +66,7 @@ public class Config {
     public static ForgeConfigSpec.IntValue MANABAR_X_OFFSET;
     public static ForgeConfigSpec.IntValue MANABAR_Y_OFFSET;
     public static ForgeConfigSpec.IntValue BOOKWYRM_LIMIT;
+    public static ForgeConfigSpec.BooleanValue GUI_TRANSPARENCY;
 
     private static ForgeConfigSpec.ConfigValue<List<? extends String>> ENTITY_LIGHT_CONFIG;
     private static ForgeConfigSpec.ConfigValue<List<? extends String>> ITEM_LIGHT_CONFIG;
@@ -112,6 +113,7 @@ public class Config {
         CLIENT_BUILDER.comment("Misc").push("misc");
         ALTERNATE_PORTAL_RENDER = CLIENT_BUILDER.comment("Use simplified renderer for Warp Portals").define("no_end_portal_render", false);
         DISABLE_SKY_SHADER = CLIENT_BUILDER.comment("Disables the skyweave renderer. Disable if your sky is broken with shaders.").define("disable_skyweave", false);
+        GUI_TRANSPARENCY = CLIENT_BUILDER.comment("Enables transparent/opaque rendering of elements in the book GUI. Disable if it leads to crash with Sodium derivatives").define("gui_transparency", true);
         SERVER_BUILDER.comment("General settings").push(CATEGORY_GENERAL);
         DIMENSION_BLACKLIST = SERVER_BUILDER.comment("Dimensions where hostile mobs will not spawn. Ex: [\"minecraft:overworld\", \"undergarden:undergarden\"]. . Run /forge dimensions for a list.").defineList("dimensionBlacklist", new ArrayList<>(), (o) -> true);
         SPAWN_BOOK = SERVER_BUILDER.comment("Spawn a book in the players inventory on login").define("spawnBook", true);


### PR DESCRIPTION
1) Add a config to disable the transparency stuff that crash with newer rubidium, as there is currently a split on mods that only support 0.6 and those that moved to support 0.7

2) Fix override methods in summoned vex having wrong signature and add an alternative getOwner to not clash with superclass as AllyVex use a private Owner field (as superclass uses Mob instead of LivingEntity)