### PR TITLE
Fix patchouli's could not find entry error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ curios_version=5.1.1.0
 gecko_version=4.2.2
 mixin_extras_version=0.2.0-beta.8
 forge_version=47.1.64
-patchouli_version=1.20.1-80-FORGE
+patchouli_version=1.20.1-83-FORGE

--- a/src/generated/resources/assets/ars_nouveau/patchouli_books/worn_notebook/en_us/entries/familiars/summoning_familiars.json
+++ b/src/generated/resources/assets/ars_nouveau/patchouli_books/worn_notebook/en_us/entries/familiars/summoning_familiars.json
@@ -19,7 +19,7 @@
       "type": "patchouli:relations",
       "entries": [
         "ars_nouveau:machines/ritual_brazier",
-        "ars_nouveau:rituals/binding"
+        "ars_nouveau:rituals/ritual_binding"
       ]
     }
   ],

--- a/src/generated/resources/assets/ars_nouveau/patchouli_books/worn_notebook/en_us/entries/getting_started/upgrades.json
+++ b/src/generated/resources/assets/ars_nouveau/patchouli_books/worn_notebook/en_us/entries/getting_started/upgrades.json
@@ -10,8 +10,7 @@
     {
       "type": "patchouli:relations",
       "entries": [
-        "ars_nouveau:equipment/spell_books",
-        "ars_nouveau:equipment/armor"
+        "ars_nouveau:equipment/spell_books"
       ]
     }
   ],


### PR DESCRIPTION
Due to a change in patchouli's error handling, it now does not skip non-exsisting/faulty entries, but it will throw an error on the second page on the book. I believe this is to better help mod developers manage their books and reduce debugging time.

Ars Nouveau had two faulty relationship entries, which where not existen. Patchouli's update made it that it did not render the pages.

These changes fix the issues.

- [Bumped patchouli dep to 1.20.1-83-FORGE](https://github.com/baileyholl/Ars-Nouveau/commit/28a8a6f5f4d276442dce03425f1c5788edb2b326)
- [Changed ars_nouveau:rituals/binding to ars_nouveau:rituals/binding in…](https://github.com/baileyholl/Ars-Nouveau/commit/6d4018ad364245674db7097f76d26bfeb2841161)
- [Removed ars_nouveau:equipment in src/generated/resources/assets/ars_n…](https://github.com/baileyholl/Ars-Nouveau/commit/e63454d20bd5c359bdaabd1a64451abf2daa73ee)
