### PR TITLE
Arc bounce hotfix

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityProjectileSpell.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityProjectileSpell.java
@@ -345,8 +345,10 @@ public class EntityProjectileSpell extends ColoredProjectile implements IEntityA
 
                 if (canBounce()) {
                     bounce(blockraytraceresult);
-                    pierceLeft--; //to replace with bounce field eventually
-                    if (numSensitive > 1) return;
+                    if (numSensitive > 1) {
+                        pierceLeft--; //to replace with bounce field eventually, reduce here since we're not calling attemptRemoval
+                        return;
+                    }
                 }
 
                 if (this.spellResolver != null) {


### PR DESCRIPTION
The pierce counter is reduced on bouncing, but is then reduced again on attemptRemoval (effectively wasting half pierces).

Moves pierce counter reduction to the isSensitive check, where attemptRemoval is not called.