### PR TITLE
Fix that damn jei arrow + glowstone parity with quartz

### DIFF
--- a/src/generated/resources/.cache/43f70b1d0fc3650d25dddf44c6efffef1900bb18
+++ b/src/generated/resources/.cache/43f70b1d0fc3650d25dddf44c6efffef1900bb18
@@ -1,7 +1,8 @@
-// 1.20.1	2023-12-01T19:20:08.3260388	Crush
+// 1.20.1	2024-04-27T13:00:27.3118577	Crush
 89f6c5048e41f3226ef9bdda74f014fb860b464a data/ars_nouveau/recipes/crush_blue_dye.json
 d44de9a1af0d9b28eb63f2376ec9d7e9b08eaec3 data/ars_nouveau/recipes/crush_brown_dye.json
 9c59b21719e0446a5660c0002da247acdc0e5517 data/ars_nouveau/recipes/crush_cobblestone.json
+e86ed58be6f713d3f8b5aa179b2930ee000f1a92 data/ars_nouveau/recipes/crush_glowstone_block_to_dust.json
 b08c2a6794259f444d5e418550c19c8f55675db4 data/ars_nouveau/recipes/crush_gravel.json
 9cbcf2d638d6574a5b6bf58f9339e91bab5d9c10 data/ars_nouveau/recipes/crush_light_blue_dye.json
 b9abeab71d6e16b2213eb0c61e226bb2816e6ac2 data/ars_nouveau/recipes/crush_light_gray_dye_azure.json

--- a/src/generated/resources/data/ars_nouveau/recipes/crush_glowstone_block_to_dust.json
+++ b/src/generated/resources/data/ars_nouveau/recipes/crush_glowstone_block_to_dust.json
@@ -1,0 +1,15 @@
+{
+  "type": "ars_nouveau:crush",
+  "input": {
+    "item": "minecraft:glowstone"
+  },
+  "output": [
+    {
+      "chance": 1.0,
+      "count": 4,
+      "item": "minecraft:glowstone_dust",
+      "maxRange": 1
+    }
+  ],
+  "skip_block_place": false
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/JEIConstants.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/JEIConstants.java
@@ -3,9 +3,10 @@ package com.hollingsworth.arsnouveau.client.jei;
 import net.minecraft.resources.ResourceLocation;
 
 public class JEIConstants {
-    public static final String TEXTURE_GUI_PATH = "textures/gui/";
-    public static final String TEXTURE_GUI_VANILLA = "textures/gui/gui_vanilla.png";
-    public static final ResourceLocation RECIPE_GUI_VANILLA = new ResourceLocation("jei", "textures/gui/gui_vanilla.png");
+    public static final String TEXTURE_GUI_PATH = "textures/jei/gui/";
+    public static final String TEXTURE_GUI_VANILLA = TEXTURE_GUI_PATH + "gui_vanilla.png";
+    public static final ResourceLocation RECIPE_GUI_VANILLA = new ResourceLocation("jei", TEXTURE_GUI_VANILLA);
+
     public static final int MAX_TOOLTIP_WIDTH = 150;
     public static final ResourceLocation UNIVERSAL_RECIPE_TRANSFER_UID = new ResourceLocation("jei", "universal_recipe_transfer_handler");
     public static final ResourceLocation LOCATION_JEI_GUI_TEXTURE_ATLAS = new ResourceLocation("jei", "textures/atlas/gui.png");

--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/CrushRecipeProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/CrushRecipeProvider.java
@@ -7,6 +7,7 @@ import net.minecraft.data.DataGenerator;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.common.Tags;
 
 import java.nio.file.Path;
@@ -53,6 +54,7 @@ public class CrushRecipeProvider extends SimpleDataProvider {
         recipes.add(new CrushRecipe("sugar_cane", Ingredient.of(Items.SUGAR_CANE)).withItems(new ItemStack(Items.SUGAR, 2)));
         recipes.add(new CrushRecipe("sandstone_to_sand", Ingredient.of(Items.SANDSTONE)).withItems(Items.SAND.getDefaultInstance()));
         recipes.add(new CrushRecipe("quartz_block_to_quartz", Ingredient.of(Tags.Items.STORAGE_BLOCKS_QUARTZ)).withItems((new ItemStack(Items.QUARTZ, 4))));
+        recipes.add(new CrushRecipe("glowstone_block_to_dust", Ingredient.of(Blocks.GLOWSTONE)).withItems((new ItemStack(Items.GLOWSTONE_DUST, 4))));
 
 
         for (CrushRecipe g : recipes) {


### PR DESCRIPTION
Adds a crush recipe to get the full 4 dusts from glowstone, fix the missing texture on crush recipes in jei