### PR TITLE
Allow regex to parse any char in the resourcelocation part of the string

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/setup/config/ConfigUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/setup/config/ConfigUtil.java
@@ -16,7 +16,7 @@ public class ConfigUtil {
      * Expected format is "string=int"
      * Example: "fortune=3"
      */
-    public static final Pattern STRING_INT_MAP = Pattern.compile("([^/=]+)=(\\p{Digit}+)");
+    public static final Pattern STRING_INT_MAP = Pattern.compile("(.+?)=(\\d+)");
 
     /** Parse glyph_limits into a Map from augment glyph tags to limits. */
     public static Map<String, Integer> parseMapConfig(ForgeConfigSpec.ConfigValue<List<? extends String>> configValue) {


### PR DESCRIPTION
for ids like  "everycomp:ch/ars_nouveau/archwood_torch=15" that failed otherwise