### PR TITLE
fix: ignore frozen ticks in EventQueue

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/event/EventQueue.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/event/EventQueue.java
@@ -15,6 +15,7 @@ import java.util.List;
 /**
  * For queuing deferred or over-time tasks. Tick refers to the Server or Client Tick event.
  */
+@SuppressWarnings("ForLoopReplaceableByForEach")
 @EventBusSubscriber(modid = ArsNouveau.MODID)
 public class EventQueue {
     @NotNull List<ITimedEvent> events = new ObjectArrayList<>();

--- a/src/main/java/com/hollingsworth/arsnouveau/api/event/EventQueue.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/event/EventQueue.java
@@ -1,6 +1,7 @@
 package com.hollingsworth.arsnouveau.api.event;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
+import net.minecraft.server.ServerTickRateManager;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
@@ -73,14 +74,26 @@ public class EventQueue {
         events = new ArrayList<>();
     }
 
+    private static boolean tickStepping = false;
+
     @SubscribeEvent
     public static void serverTick(ServerTickEvent.Post e) {
+        ServerTickRateManager trm = e.getServer().tickRateManager();
+
+        if (trm.isFrozen() && !tickStepping && !trm.isSprinting()) {
+            return;
+        }
+
         EventQueue.getServerInstance().tick(e);
+    }
+
+    @SubscribeEvent
+    public static void serverTickPre(ServerTickEvent.Pre e) {
+        tickStepping = e.getServer().tickRateManager().isSteppingForward();
     }
 
     @SubscribeEvent
     public static void clientTickEvent(ClientTickEvent.Post e) {
         EventQueue.getClientQueue().tick(null);
     }
-
 }


### PR DESCRIPTION
1.21 adds /tick, which allows you to freeze the game. 

NeoForge will fire ServerTickEvent.Post regardless of whether the game is frozen. 

We also can not observe the effects of a one-tick tick step in ServerTickEvent.Post, so we need to hook into ServerTickEvent.Pre to find out if it was stepping.