### PR TITLE
Hats Off! Cosmetic system for familiars restored and upgraded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.neoforged.gradle.userdev' version '7.0.145'
+    id 'net.neoforged.gradle.userdev' version '7.0.+'
 }
 
 version = mod_version
@@ -24,7 +24,7 @@ java.withSourcesJar()
 
 subsystems {
     parchment {
-        minecraftVersion = "1.20.6"
+        minecraftVersion = "1.21"
         mappingsVersion = project.parchment_version
     }
 }
@@ -43,7 +43,7 @@ runs {
     }
 
     data {
-        programArguments.addAll '--mod', mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath()
+        getArguments().addAll '--mod', mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath()
     }
 }
 
@@ -104,7 +104,7 @@ dependencies {
 //    jarJar(group: 'software.bernie.geckolib', name: "geckolib-neoforge-${minecraft_version}", version: "[4.5,)") {
 //        jarJar.pin(it, "${geckolib_version}")
 //    }
-    implementation "software.bernie.geckolib:geckolib-neoforge-1.21:${geckolib_version}"
+    implementation "software.bernie.geckolib:geckolib-neoforge-1.21.1:${geckolib_version}"
 //
     implementation(jarJar(group: 'vazkii.patchouli', name: 'Patchouli', version: '[1.21,)') {
         jarJar.pin(it, patchouli_version)
@@ -117,7 +117,7 @@ dependencies {
     implementation "mezz.jei:jei-1.21-neoforge:${jei_version}"
     implementation 'com.github.glitchfiend:TerraBlender-neoforge:1.21-4.0.0.0'
     implementation "curse.maven:jade-324717:5444008"
-    implementation 'top.theillusivec4.curios:curios-neoforge:9.0.4+1.21'
+    implementation "top.theillusivec4.curios:curios-neoforge:${curios_version}+1.21"
 
     implementation "curse.maven:ars-additions-974408:5698511"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,16 @@
 org.gradle.jvmargs=-Xmx4G
 org.gradle.daemon=false
 org.gradle.debug=false
-
-neogradle.subsystems.parchment.minecraftVersion=1.20.6
-neogradle.subsystems.parchment.mappingsVersion=2024.05.01
+neogradle.subsystems.decompiler.maxMemory=4G
+neogradle.subsystems.recompiler.maxMemory=4G
+neogradle.subsystems.parchment.minecraftVersion=1.21.0
+neogradle.subsystems.parchment.mappingsVersion=2024.07.28
 
 minecraft_version=1.21.0
-parchment_version=2024.05.01
-minecraft_version_range=[1.20.6,1.21)
-neo_version=21.1.13
-neo_version_range=[20.6,)
+parchment_version=2024.07.28
+minecraft_version_range=[1.20.6,1.21.2)
+neo_version=21.1.66
+neo_version_range=[21,)
 loader_version_range=[2,)
 
 mod_id=ars_nouveau
@@ -23,7 +24,7 @@ mod_authors=Bailey Hollingsworth
 mod_description=Craft spells, create powerful baubles, and summon magical creatures!
 
 jei_version=19.5.0.44
-curios_version=8.0.0-beta
-geckolib_version=4.5.7
-patchouli_version=87-NEOFORGE-SNAPSHOT
+curios_version=9.0.12
+geckolib_version=4.6.6
+patchouli_version=88-NEOFORGE-SNAPSHOT
 caelus_version=7.0.0+1.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/hollingsworth/arsnouveau/api/item/ICosmeticItem.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/item/ICosmeticItem.java
@@ -8,18 +8,28 @@ import net.neoforged.api.distmarker.OnlyIn;
 
 public interface ICosmeticItem {
 
+    Vec3 defaultScaling = new Vec3(1.0, 1.0, 1.0);
+
     //bone model where the item is renderer, all animations that include the bone will be synced with the item
-    default String getBone() {
+    default String getBone(LivingEntity entity) {
         return "head";
     }
 
-    //translate relative to bone pivot
-    Vec3 getTranslations();
+    /**
+     * translate relative to bone pivot specified by {@link ICosmeticItem#getBone}
+     */
+    default Vec3 getTranslations() {
+        return Vec3.ZERO;
+    }
 
-    Vec3 getScaling();
+    default Vec3 getScaling() {
+        return defaultScaling;
+    }
 
-    //Entity Sensitive
-    //translate relative to bone pivot
+    /**
+     * Entity Sensitive
+     * translate relative to bone pivot specified by {@link ICosmeticItem#getBone}
+     */
     default Vec3 getTranslations(LivingEntity entity) {
         return getTranslations();
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/registry/ClientHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/registry/ClientHandler.java
@@ -11,10 +11,7 @@ import com.hollingsworth.arsnouveau.client.gui.GuiManaHUD;
 import com.hollingsworth.arsnouveau.client.gui.GuiSpellHUD;
 import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
 import com.hollingsworth.arsnouveau.client.renderer.entity.*;
-import com.hollingsworth.arsnouveau.client.renderer.entity.familiar.AnimSkullRenderer;
-import com.hollingsworth.arsnouveau.client.renderer.entity.familiar.FamiliarBookwyrmRenderer;
-import com.hollingsworth.arsnouveau.client.renderer.entity.familiar.FamiliarStarbyModel;
-import com.hollingsworth.arsnouveau.client.renderer.entity.familiar.FamiliarWhirlisprigRenderer;
+import com.hollingsworth.arsnouveau.client.renderer.entity.familiar.*;
 import com.hollingsworth.arsnouveau.client.renderer.tile.*;
 import com.hollingsworth.arsnouveau.common.block.tile.MageBlockTile;
 import com.hollingsworth.arsnouveau.common.block.tile.PotionJarTile;
@@ -22,9 +19,7 @@ import com.hollingsworth.arsnouveau.common.block.tile.PotionMelderTile;
 import com.hollingsworth.arsnouveau.common.entity.EntityDrygmy;
 import com.hollingsworth.arsnouveau.common.entity.EntityWixie;
 import com.hollingsworth.arsnouveau.common.entity.Whirlisprig;
-import com.hollingsworth.arsnouveau.common.entity.familiar.FamiliarDrygmy;
 import com.hollingsworth.arsnouveau.common.entity.familiar.FamiliarStarbuncle;
-import com.hollingsworth.arsnouveau.common.entity.familiar.FamiliarWixie;
 import com.hollingsworth.arsnouveau.common.items.data.ArmorPerkHolder;
 import com.hollingsworth.arsnouveau.common.items.data.BlockFillContents;
 import com.hollingsworth.arsnouveau.common.items.data.PotionJarData;
@@ -37,6 +32,8 @@ import net.minecraft.client.Options;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.LayeredDraw;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.*;
 import net.minecraft.client.renderer.item.ClampedItemPropertyFunction;
 import net.minecraft.client.renderer.item.ItemProperties;
@@ -122,13 +119,13 @@ public class ClientHandler {
         event.registerEntityRenderer(ModEntities.ALLY_VEX.get(), VexRenderer::new);
 
         event.registerEntityRenderer(ModEntities.STARBUNCLE_TYPE.get(), StarbuncleRenderer::new);
-        event.registerEntityRenderer(ModEntities.WHIRLISPRIG_TYPE.get(), (t) -> new GeoEntityRenderer<>(t, new WhirlisprigModel<>()){
+        event.registerEntityRenderer(ModEntities.WHIRLISPRIG_TYPE.get(), (t) -> new GeoEntityRenderer<>(t, new WhirlisprigModel<>()) {
             @Override
             public @NotNull ResourceLocation getTextureLocation(@NotNull Whirlisprig animatable) {
                 return animatable.getTexture();
             }
         });
-        event.registerEntityRenderer(ModEntities.ENTITY_WIXIE_TYPE.get(), (t) -> new GeoEntityRenderer<>(t, new WixieModel<>()){
+        event.registerEntityRenderer(ModEntities.ENTITY_WIXIE_TYPE.get(), (t) -> new GeoEntityRenderer<>(t, new WixieModel<>()) {
             @Override
             public @NotNull ResourceLocation getTextureLocation(@NotNull EntityWixie animatable) {
                 return animatable.getTexture();
@@ -146,14 +143,14 @@ public class ClientHandler {
         event.registerEntityRenderer(ModEntities.ENTITY_RITUAL.get(),
                 renderManager -> new RenderBlank(renderManager, ArsNouveau.prefix("textures/entity/spell_proj.png")));
         event.registerEntityRenderer(ModEntities.ENTITY_SPELL_ARROW.get(), TippableArrowRenderer::new);
-        event.registerEntityRenderer(ModEntities.ENTITY_WIXIE_TYPE.get(), (t) -> new GeoEntityRenderer<>(t, new WixieModel<>()){
+        event.registerEntityRenderer(ModEntities.ENTITY_WIXIE_TYPE.get(), (t) -> new GeoEntityRenderer<>(t, new WixieModel<>()) {
             @Override
             public @NotNull ResourceLocation getTextureLocation(@NotNull EntityWixie animatable) {
                 return animatable.getTexture();
             }
         });
         event.registerEntityRenderer(ModEntities.ENTITY_DUMMY.get(), DummyRenderer::new);
-        event.registerEntityRenderer(ModEntities.ENTITY_DRYGMY.get(), (t) -> new GeoEntityRenderer<>(t, new DrygmyModel<>()){
+        event.registerEntityRenderer(ModEntities.ENTITY_DRYGMY.get(), (t) -> new GeoEntityRenderer<>(t, new DrygmyModel<>()) {
             @Override
             public @NotNull ResourceLocation getTextureLocation(@NotNull EntityDrygmy animatable) {
                 return animatable.getTexture();
@@ -162,34 +159,24 @@ public class ClientHandler {
         event.registerEntityRenderer(ModEntities.ORBIT_SPELL.get(), renderManager -> new RenderBlank(renderManager, ArsNouveau.prefix("textures/entity/spell_proj.png")));
         event.registerEntityRenderer(ModEntities.WILDEN_BOSS.get(), rendermanager -> new GeoEntityRenderer<>(rendermanager, new WildenChimeraModel()));
         event.registerEntityRenderer(ModEntities.ENTITY_CHIMERA_SPIKE.get(), ChimeraProjectileRenderer::new);
-        event.registerEntityRenderer(ModEntities.ENTITY_FAMILIAR_STARBUNCLE.get(), (t) -> new GeoEntityRenderer<>(t, new FamiliarStarbyModel<>()){
+        event.registerEntityRenderer(ModEntities.ENTITY_FAMILIAR_STARBUNCLE.get(), (t) -> new GenericFamiliarRenderer<>(t, new FamiliarStarbyModel<>()) {
             @Override
-            public @NotNull ResourceLocation getTextureLocation(@NotNull FamiliarStarbuncle animatable) {
-                return animatable.getTexture();
+            public @Nullable RenderType getRenderType(FamiliarStarbuncle animatable, ResourceLocation texture, @Nullable MultiBufferSource bufferSource, float partialTick) {
+                return StarbuncleRenderer.specialShaders.getOrDefault(animatable.getName().getString(), RenderType::entityCutoutNoCull).apply(texture);
             }
         });
-        event.registerEntityRenderer(ModEntities.ENTITY_FAMILIAR_DRYGMY.get(), (t) -> new GeoEntityRenderer<>(t, new DrygmyModel<>()){
-            @Override
-            public @NotNull ResourceLocation getTextureLocation(@NotNull FamiliarDrygmy animatable) {
-                return animatable.getTexture();
-            }
-        });
+        event.registerEntityRenderer(ModEntities.ENTITY_FAMILIAR_DRYGMY.get(), (t) -> new GenericFamiliarRenderer<>(t, new DrygmyModel<>()));
         event.registerEntityRenderer(ModEntities.ENTITY_FAMILIAR_SYLPH.get(), FamiliarWhirlisprigRenderer::new);
-        event.registerEntityRenderer(ModEntities.ENTITY_FAMILIAR_WIXIE.get(), (t) -> new GeoEntityRenderer<>(t, new WixieModel<>()){
-            @Override
-            public ResourceLocation getTextureLocation(FamiliarWixie animatable) {
-                return animatable.getTexture();
-            }
-        });
+        event.registerEntityRenderer(ModEntities.ENTITY_FAMILIAR_WIXIE.get(), (t) -> new GenericFamiliarRenderer<>(t, new WixieModel<>()));
         event.registerEntityRenderer(ModEntities.ENTITY_BOOKWYRM_TYPE.get(), BookwyrmRenderer::new);
         event.registerEntityRenderer(ModEntities.FAMILIAR_AMETHYST_GOLEM.get(), AmethystGolemRenderer::new);
         event.registerEntityRenderer(ModEntities.ENTITY_FAMILIAR_BOOKWYRM.get(), FamiliarBookwyrmRenderer::new);
         event.registerEntityRenderer(ModEntities.LINGER_SPELL.get(),
                 renderManager -> new RenderBlank(renderManager, ArsNouveau.prefix("textures/entity/spell_proj.png")));
         event.registerEntityRenderer(ModEntities.ENTITY_CASCADING_WEALD.get(), (v) -> new GeoEntityRenderer<>(v, new WealdWalkerModel<>("cascading_weald")));
-        event.registerEntityRenderer(ModEntities.ENTITY_BLAZING_WEALD.get(), (v) -> new GeoEntityRenderer<>(v,  new WealdWalkerModel<>("blazing_weald")));
-        event.registerEntityRenderer(ModEntities.ENTITY_FLOURISHING_WEALD.get(), (v) -> new GeoEntityRenderer<>(v,  new WealdWalkerModel<>("flourishing_weald")));
-        event.registerEntityRenderer(ModEntities.ENTITY_VEXING_WEALD.get(), (v) -> new GeoEntityRenderer<>(v,  new WealdWalkerModel<>("vexing_weald")));
+        event.registerEntityRenderer(ModEntities.ENTITY_BLAZING_WEALD.get(), (v) -> new GeoEntityRenderer<>(v, new WealdWalkerModel<>("blazing_weald")));
+        event.registerEntityRenderer(ModEntities.ENTITY_FLOURISHING_WEALD.get(), (v) -> new GeoEntityRenderer<>(v, new WealdWalkerModel<>("flourishing_weald")));
+        event.registerEntityRenderer(ModEntities.ENTITY_VEXING_WEALD.get(), (v) -> new GeoEntityRenderer<>(v, new WealdWalkerModel<>("vexing_weald")));
 
         event.registerEntityRenderer(ModEntities.AMETHYST_GOLEM.get(), AmethystGolemRenderer::new);
         event.registerEntityRenderer(ModEntities.SCRYER_CAMERA.get(), renderManager -> new RenderBlank(renderManager, ArsNouveau.prefix("textures/entity/spell_proj.png")));
@@ -197,13 +184,13 @@ public class ClientHandler {
         event.registerEntityRenderer(ModEntities.ICE_SHARD.get(), EnchantedFallingBlockRenderer::new);
         event.registerEntityRenderer(ModEntities.ENCHANTED_MAGE_BLOCK.get(), MageBlockRenderer::new);
         event.registerEntityRenderer(ModEntities.ENCHANTED_HEAD_BLOCK.get(), EnchantedSkullRenderer::new);
-        event.registerEntityRenderer(ModEntities.GIFT_STARBY.get(),(renderer) -> new GeoEntityRenderer<>(renderer, new GiftStarbyModel()));
+        event.registerEntityRenderer(ModEntities.GIFT_STARBY.get(), (renderer) -> new GeoEntityRenderer<>(renderer, new GiftStarbyModel()));
         event.registerEntityRenderer(ModEntities.ANIMATED_BLOCK.get(), AnimBlockRenderer::new);
         event.registerEntityRenderer(ModEntities.ANIMATED_HEAD.get(), AnimSkullRenderer::new);
         event.registerEntityRenderer(ModEntities.CINDER.get(), CinderRenderer::new);
         event.registerEntityRenderer(ModEntities.WALL_SPELL.get(),
                 renderManager -> new RenderBlank(renderManager, ArsNouveau.prefix("textures/entity/spell_proj.png")));
-        event.registerEntityRenderer(ModEntities.LILY.get(),  (v) -> new GeoEntityRenderer<>(v, new LilyModel()));
+        event.registerEntityRenderer(ModEntities.LILY.get(), (v) -> new GeoEntityRenderer<>(v, new LilyModel()));
     }
 
     public static LayeredDraw.Layer cameraOverlay = (gui, tracker) -> {
@@ -249,7 +236,7 @@ public class ClientHandler {
             });
             ItemProperties.register(ItemsRegistry.DOWSING_ROD.get(), ArsNouveau.prefix("uses"), new ClampedItemPropertyFunction() {
                 @Override
-                public float unclampedCall(ItemStack pStack, @Nullable ClientLevel pLevel, @Nullable LivingEntity pEntity, int pSeed) {
+                public float unclampedCall(@NotNull ItemStack pStack, @Nullable ClientLevel pLevel, @Nullable LivingEntity pEntity, int pSeed) {
                     return switch (pStack.getDamageValue()) {
                         case 1 -> 0.75f;
                         case 2 -> 0.50f;
@@ -379,7 +366,7 @@ public class ClientHandler {
     public static int colorFromFlask(ItemStack stack) {
         PotionContents contents = PotionUtil.getContents(stack);
         var provider = PotionProviderRegistry.from(stack);
-        if(provider != null){
+        if (provider != null) {
             return provider.usesRemaining(stack) <= 0 ? 0 : provider.getPotionData(stack).getColor();
         }
         return contents == PotionContents.EMPTY ? -1 : contents.getColor();

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/StarbuncleModel.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/StarbuncleModel.java
@@ -14,13 +14,14 @@ import javax.annotation.Nullable;
 public class StarbuncleModel extends GeoModel<Starbuncle> {
 
     @Override
-    public void setCustomAnimations(Starbuncle entity, long uniqueID, @Nullable AnimationState customPredicate) {
+    public void setCustomAnimations(Starbuncle entity, long uniqueID, @Nullable AnimationState<Starbuncle> customPredicate) {
         super.setCustomAnimations(entity, uniqueID, customPredicate);
         if (entity.partyCarby)
             return;
         if (customPredicate == null)
             return;
-        this.getBone("basket").get().setHidden(!entity.isTamed());
+        if (this.getBone("basket").isPresent())
+            this.getBone("basket").get().setHidden(!entity.isTamed());
 
         GeoBone head = this.getAnimationProcessor().getBone("head");
         EntityModelData extraData = (EntityModelData) customPredicate.getExtraData().get(DataTickets.ENTITY_MODEL_DATA);
@@ -35,11 +36,11 @@ public class StarbuncleModel extends GeoModel<Starbuncle> {
 
     @Override
     public ResourceLocation getTextureResource(Starbuncle carbuncle) {
-        return carbuncle.getTexture(carbuncle);
+        return carbuncle.getTexture();
     }
 
     @Override
     public ResourceLocation getAnimationResource(Starbuncle carbuncle) {
-        return ArsNouveau.prefix( "animations/starbuncle_animations.json");
+        return ArsNouveau.prefix("animations/starbuncle_animations.json");
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/WixieModel.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/WixieModel.java
@@ -1,6 +1,8 @@
 package com.hollingsworth.arsnouveau.client.renderer.entity;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
+import com.hollingsworth.arsnouveau.api.item.ICosmeticItem;
+import com.hollingsworth.arsnouveau.common.entity.familiar.FamiliarWixie;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import software.bernie.geckolib.animatable.GeoAnimatable;
@@ -23,6 +25,11 @@ public class WixieModel<T extends LivingEntity & GeoAnimatable> extends GeoModel
         EntityModelData extraData = (EntityModelData) customPredicate.getExtraData().get(DataTickets.ENTITY_MODEL_DATA);
         head.setRotX(extraData.headPitch() * 0.010453292F);
         head.setRotY(extraData.netHeadYaw() * 0.015453292F);
+        if (entity instanceof FamiliarWixie w) {
+            // hides the hat bone if the cosmetic item is a hat
+            this.getAnimationProcessor().getBone("hat")
+                    .setHidden(w.getCosmeticItem().getItem() instanceof ICosmeticItem cosmetic && cosmetic.getBone(w).equals("hat"));
+        }
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/familiar/FamiliarBookwyrmRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/familiar/FamiliarBookwyrmRenderer.java
@@ -5,10 +5,8 @@ import com.hollingsworth.arsnouveau.common.entity.familiar.FamiliarBookwyrm;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
-import net.minecraft.resources.ResourceLocation;
-import software.bernie.geckolib.renderer.GeoEntityRenderer;
 
-public class FamiliarBookwyrmRenderer extends GeoEntityRenderer<FamiliarBookwyrm> {
+public class FamiliarBookwyrmRenderer extends GenericFamiliarRenderer<FamiliarBookwyrm> {
     public FamiliarBookwyrmRenderer(EntityRendererProvider.Context renderManager) {
         super(renderManager, new BookwyrmModel<>());
     }
@@ -21,8 +19,4 @@ public class FamiliarBookwyrmRenderer extends GeoEntityRenderer<FamiliarBookwyrm
         stack.popPose();
     }
 
-    @Override
-    public ResourceLocation getTextureLocation(FamiliarBookwyrm entity) {
-        return entity.getTexture();
-    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/familiar/FamiliarStarbyModel.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/familiar/FamiliarStarbyModel.java
@@ -23,12 +23,12 @@ public class FamiliarStarbyModel<T extends FamiliarStarbuncle> extends GeoModel<
     }
 
     @Override
-    public ResourceLocation getModelResource(FamiliarStarbuncle carbuncle) {
-        return ArsNouveau.prefix( "geo/starbuncle.geo.json");
+    public ResourceLocation getModelResource(T carbuncle) {
+        return carbuncle.getModel();
     }
 
     @Override
-    public ResourceLocation getTextureResource(FamiliarStarbuncle carbuncle) {
+    public ResourceLocation getTextureResource(T carbuncle) {
         return carbuncle.getTexture();
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/familiar/FamiliarWhirlisprigRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/familiar/FamiliarWhirlisprigRenderer.java
@@ -9,15 +9,13 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import software.bernie.geckolib.cache.object.GeoBone;
-import software.bernie.geckolib.renderer.GeoEntityRenderer;
 
 import java.util.Random;
 
-public class FamiliarWhirlisprigRenderer extends GeoEntityRenderer<FamiliarWhirlisprig> {
+public class FamiliarWhirlisprigRenderer extends GenericFamiliarRenderer<FamiliarWhirlisprig> {
 
     public FamiliarWhirlisprigRenderer(EntityRendererProvider.Context renderManager) {
         super(renderManager, new WhirlisprigModel<>());
@@ -48,8 +46,4 @@ public class FamiliarWhirlisprigRenderer extends GeoEntityRenderer<FamiliarWhirl
         }
     }
 
-    @Override
-    public ResourceLocation getTextureLocation(FamiliarWhirlisprig animatable) {
-        return animatable.getTexture();
-    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/familiar/GenericFamiliarRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/entity/familiar/GenericFamiliarRenderer.java
@@ -1,0 +1,40 @@
+package com.hollingsworth.arsnouveau.client.renderer.entity.familiar;
+
+import com.hollingsworth.arsnouveau.api.client.CosmeticRenderUtil;
+import com.hollingsworth.arsnouveau.api.item.ICosmeticItem;
+import com.hollingsworth.arsnouveau.common.entity.familiar.FamiliarEntity;
+import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+import software.bernie.geckolib.cache.object.GeoBone;
+import software.bernie.geckolib.model.GeoModel;
+import software.bernie.geckolib.renderer.GeoEntityRenderer;
+
+public class GenericFamiliarRenderer<T extends FamiliarEntity> extends GeoEntityRenderer<T> {
+
+    public GenericFamiliarRenderer(EntityRendererProvider.Context renderManager, GeoModel<T> model) {
+        super(renderManager, model);
+    }
+
+    public static MultiBufferSource.BufferSource cosmeticBuffer = MultiBufferSource.immediate(new ByteBufferBuilder(1536));
+
+    @Override
+    public void renderRecursively(PoseStack stack, T familiar, GeoBone bone, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, int color) {
+        if (familiar.getCosmeticItem().getItem() instanceof ICosmeticItem cosmetic && cosmetic.getBone(familiar).equals(bone.getName())) {
+            CosmeticRenderUtil.renderCosmetic(bone, stack, cosmeticBuffer, familiar, packedLight);
+            cosmeticBuffer.endBatch();
+        }
+        super.renderRecursively(stack, familiar, bone, renderType, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, color);
+    }
+
+    @Override
+    public @NotNull ResourceLocation getTextureLocation(T entity) {
+        return entity.getTexture() == null ? super.getTextureLocation(entity) : entity.getTexture();
+    }
+
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/Starbuncle.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/Starbuncle.java
@@ -703,8 +703,8 @@ public class Starbuncle extends PathfinderMob implements GeoEntity, IDecoratable
         }
     };
 
-    public ResourceLocation getTexture(Starbuncle entity) {
-        var nameTexture = TEXTURES.get(entity.getName().getString());
+    public ResourceLocation getTexture() {
+        var nameTexture = TEXTURES.get(this.getName().getString());
         if(nameTexture != null){
             return nameTexture;
         }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarEntity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarEntity.java
@@ -36,6 +36,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.animatable.instance.AnimatableInstanceCache;
 import software.bernie.geckolib.animation.AnimatableManager;
@@ -44,10 +45,9 @@ import software.bernie.geckolib.animation.AnimationState;
 import software.bernie.geckolib.animation.PlayState;
 import software.bernie.geckolib.util.GeckoLibUtil;
 
-import javax.annotation.Nullable;
 import java.util.*;
 
-public class FamiliarEntity extends PathfinderMob implements GeoEntity, IFamiliar, IDispellable, IDecoratable {
+public abstract class FamiliarEntity extends PathfinderMob implements GeoEntity, IFamiliar, IDispellable, IDecoratable {
 
     public double manaReserveModifier = 0.15;
     private static final EntityDataAccessor<Optional<UUID>> OWNER_UUID = SynchedEntityData.defineId(FamiliarEntity.class, EntityDataSerializers.OPTIONAL_UUID);
@@ -328,4 +328,10 @@ public class FamiliarEntity extends PathfinderMob implements GeoEntity, IFamilia
             setCosmeticItem(persistentData.cosmetic(), false);
         }
     }
+
+    /**
+     * Use this to return custom texture, return null for default model.
+     */
+    public abstract @Nullable ResourceLocation getTexture();
+
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarJabberwog.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarJabberwog.java
@@ -1,12 +1,14 @@
 package com.hollingsworth.arsnouveau.common.entity.familiar;
 
 import com.hollingsworth.arsnouveau.api.event.SpellModifierEvent;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
 import software.bernie.geckolib.animation.AnimationState;
-import software.bernie.geckolib.animation.RawAnimation;
 import software.bernie.geckolib.animation.PlayState;
+import software.bernie.geckolib.animation.RawAnimation;
 
 
 public class FamiliarJabberwog extends FlyingFamiliarEntity {
@@ -24,7 +26,7 @@ public class FamiliarJabberwog extends FlyingFamiliarEntity {
     }
 
     @Override
-    public PlayState walkPredicate(AnimationState event) {
+    public PlayState walkPredicate(AnimationState<? extends FamiliarEntity> event) {
         if (event.isMoving()) {
             event.getController().setAnimation(RawAnimation.begin().thenPlay("hop"));
             return PlayState.CONTINUE;
@@ -35,8 +37,13 @@ public class FamiliarJabberwog extends FlyingFamiliarEntity {
 
 
     @Override
-    public EntityType<?> getType() {
+    public @NotNull EntityType<?> getType() {
         return null;
 //        return ModEntities.ENTITY_FAMILIAR_JABBERWOG.get();
+    }
+
+    @Override
+    public ResourceLocation getTexture() {
+        return null;
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarStarbuncle.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarStarbuncle.java
@@ -1,6 +1,5 @@
 package com.hollingsworth.arsnouveau.common.entity.familiar;
 
-import com.hollingsworth.arsnouveau.ArsNouveau;
 import com.hollingsworth.arsnouveau.api.scrying.CompoundScryer;
 import com.hollingsworth.arsnouveau.api.scrying.TagScryer;
 import com.hollingsworth.arsnouveau.common.entity.Starbuncle;
@@ -27,6 +26,9 @@ import software.bernie.geckolib.animation.PlayState;
 import software.bernie.geckolib.animation.RawAnimation;
 
 import java.util.Arrays;
+
+import static com.hollingsworth.arsnouveau.common.entity.Starbuncle.MODELS;
+import static com.hollingsworth.arsnouveau.common.entity.Starbuncle.TEXTURES;
 
 public class FamiliarStarbuncle extends FamiliarEntity {
 
@@ -65,7 +67,7 @@ public class FamiliarStarbuncle extends FamiliarEntity {
     }
 
     @Override
-    public PlayState walkPredicate(AnimationState event) {
+    public PlayState walkPredicate(AnimationState<? extends FamiliarEntity> event) {
         if (event.isMoving()) {
             event.getController().setAnimation(RawAnimation.begin().thenPlay("run"));
             return PlayState.CONTINUE;
@@ -79,10 +81,18 @@ public class FamiliarStarbuncle extends FamiliarEntity {
     }
 
     public ResourceLocation getTexture() {
+        var nameTexture = TEXTURES.get(this.getName().getString());
+        if (nameTexture != null) {
+            return nameTexture;
+        }
         String color = getColor();
         if (color.isEmpty()) color = DyeColor.ORANGE.getName();
+        return TEXTURES.get(color);
+    }
 
-        return ArsNouveau.prefix( "textures/entity/starbuncle_" + color.toLowerCase() + ".png");
+    public ResourceLocation getModel() {
+        String key = getName().getString();
+        return MODELS.getOrDefault(key, MODELS.get("starbuncle"));
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarWhirlisprig.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarWhirlisprig.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.event.entity.living.LivingEntityUseItemEvent;
+import org.jetbrains.annotations.NotNull;
 import software.bernie.geckolib.animation.AnimationState;
 import software.bernie.geckolib.animation.PlayState;
 import software.bernie.geckolib.animation.RawAnimation;
@@ -31,7 +32,7 @@ public class FamiliarWhirlisprig extends FlyingFamiliarEntity implements ISpellC
 
 
     @Override
-    public InteractionResult interactAt(Player pPlayer, Vec3 pVec, InteractionHand hand) {
+    public @NotNull InteractionResult interactAt(@NotNull Player pPlayer, @NotNull Vec3 pVec, @NotNull InteractionHand hand) {
         if (hand != InteractionHand.MAIN_HAND || pPlayer.getCommandSenderWorld().isClientSide)
             return InteractionResult.PASS;
 
@@ -55,7 +56,7 @@ public class FamiliarWhirlisprig extends FlyingFamiliarEntity implements ISpellC
             Spell spell = event.context.getSpell();
             for (AbstractSpellPart part : spell.recipe()) {
                 if (SpellSchools.ELEMENTAL_EARTH.isPartOfSchool(part)) {
-                    discount += part.getCastingCost() * .5;
+                    discount += (int) (part.getCastingCost() * .5);
                 }
             }
             event.currentCost -= discount;
@@ -81,7 +82,7 @@ public class FamiliarWhirlisprig extends FlyingFamiliarEntity implements ISpellC
     }
 
     @Override
-    public PlayState walkPredicate(AnimationState event) {
+    public PlayState walkPredicate(AnimationState<? extends FamiliarEntity> event) {
         if (event.isMoving()) {
             event.getController().setAnimation(RawAnimation.begin().thenPlay("fly"));
         } else {
@@ -91,11 +92,12 @@ public class FamiliarWhirlisprig extends FlyingFamiliarEntity implements ISpellC
     }
 
     @Override
-    public EntityType<?> getType() {
+    public @NotNull EntityType<?> getType() {
         return ModEntities.ENTITY_FAMILIAR_SYLPH.get();
     }
 
     public ResourceLocation getTexture() {
         return ArsNouveau.prefix( "textures/entity/whirlisprig_" + (getColor().isEmpty() ? "summer" : getColor().toLowerCase()) + ".png");
     }
+
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FlyingFamiliarEntity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FlyingFamiliarEntity.java
@@ -7,15 +7,16 @@ import net.minecraft.world.entity.ai.control.FlyingMoveControl;
 import net.minecraft.world.entity.ai.navigation.FlyingPathNavigation;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
 
-public class FlyingFamiliarEntity extends FamiliarEntity {
+public abstract class FlyingFamiliarEntity extends FamiliarEntity {
     public FlyingFamiliarEntity(EntityType<? extends PathfinderMob> p_i48575_1_, Level p_i48575_2_) {
         super(p_i48575_1_, p_i48575_2_);
         this.moveControl = new FlyingMoveControl(this, 10, true);
     }
 
     @Override
-    protected PathNavigation createNavigation(Level world) {
+    protected @NotNull PathNavigation createNavigation(@NotNull Level world) {
         FlyingPathNavigation flyingpathnavigator = new FlyingPathNavigation(this, world);
         flyingpathnavigator.setCanOpenDoors(false);
         flyingpathnavigator.setCanFloat(true);
@@ -34,7 +35,7 @@ public class FlyingFamiliarEntity extends FamiliarEntity {
     }
 
     @Override
-    public boolean causeFallDamage(float p_147187_, float p_147188_, DamageSource p_147189_) {
+    public boolean causeFallDamage(float p_147187_, float p_147188_, @NotNull DamageSource p_147189_) {
         return false;
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/StarbuncleShades.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/StarbuncleShades.java
@@ -5,7 +5,7 @@ import com.hollingsworth.arsnouveau.api.item.ICosmeticItem;
 import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemRenderer;
 import com.hollingsworth.arsnouveau.client.renderer.tile.GenericModel;
 import com.hollingsworth.arsnouveau.common.entity.Starbuncle;
-import com.hollingsworth.arsnouveau.common.entity.familiar.FamiliarStarbuncle;
+import com.hollingsworth.arsnouveau.common.entity.familiar.*;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
@@ -20,6 +20,9 @@ import software.bernie.geckolib.animatable.client.GeoRenderProvider;
 import java.util.function.Consumer;
 
 public class StarbuncleShades extends AnimModItem implements ICosmeticItem {
+
+    public static final Vec3 starbyTrans = new Vec3(0, -.259, .165);
+    public static final Vec3 starbyScale = new Vec3(1.0, 1.0, 1.0);
 
     public StarbuncleShades() {
         super();
@@ -38,19 +41,31 @@ public class StarbuncleShades extends AnimModItem implements ICosmeticItem {
 
     @Override
     public boolean canWear(LivingEntity entity) {
-        return entity instanceof Starbuncle || entity instanceof FamiliarStarbuncle;
+        return entity instanceof Starbuncle || entity instanceof FamiliarEntity;
     }
 
     //translation applied to the renderer
     @Override
-    public Vec3 getTranslations() {
-        return new Vec3(0, -.259, .165);
+    public Vec3 getTranslations(LivingEntity entity) {
+        return switch (entity) {
+            case FamiliarBookwyrm ignored -> new Vec3(0, -.235, .095);
+            case FamiliarWixie ignored -> new Vec3(0, -.15, .26);
+            case FamiliarDrygmy ignored -> new Vec3(0, -.13, .275);
+            case FamiliarWhirlisprig ignored -> new Vec3(0, -.175, .275);
+            case null, default -> starbyTrans;
+        };
     }
 
     //scaling applied to the renderer
     @Override
-    public Vec3 getScaling() {
-        return new Vec3(1.0, 1.0, 1.0);
+    public Vec3 getScaling(LivingEntity entity) {
+        return switch (entity) {
+            case FamiliarBookwyrm ignored -> defaultScaling;
+            case FamiliarWixie ignored -> new Vec3(1.0, 1.0, 1.0);
+            case FamiliarDrygmy ignored -> defaultScaling.scale(1.125);
+            case FamiliarWhirlisprig ignored -> defaultScaling.scale(1.125);
+            case null, default -> starbyScale;
+        };
     }
 
     @Override


### PR DESCRIPTION
Restores GenericFamiliarRenderer for rendering Cosmetic Accessories on all familiars that use it. (Amet golem currently not using it)
Make ICosmeticItem#getBone entity-sensitive to switch pivot based on entity for multiple support.
Allow hiding wixie hat if the familiar has an hat cosmetic. Allow Starbuncle Shades on all familiars.