### PR TITLE
Fix item scroll data using List#remove for ItemStacks

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/ItemScrollData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/ItemScrollData.java
@@ -86,7 +86,17 @@ public class ItemScrollData implements NBTComponent<ItemScrollData>, TooltipProv
         }
 
         public boolean remove(ItemStack stack) {
-            return list.remove(stack.copy());
+            // ItemStacks do not have a proper "equals" implementation, so List#remove doesn't work
+            // (as it relies on Object#equals being properly implemented)
+            list.removeIf(stored -> ItemStack.isSameItem(stored, stack));
+            for (int i = 0; i < list.size(); i++) {
+                // Use the same check as ItemScrollData#contains
+                if (ItemStack.isSameItem(stack, list.get(i))) {
+                    list.remove(i); // Will always succeed
+                    return true;
+                }
+            }
+            return false;
         }
 
         public List<ItemStack> getItems() {


### PR DESCRIPTION
This PR fixes #1429 by changing `ItemScrollData.Mutable` from using `List#remove` for removing `ItemStacks` from the list, to using a manual iteration and comparing stacks using `ItemStack#isSameItem` (the same comparison method as `ItemScrollData#contains`).

As `ItemStack`s do not implement `Object#equals` properly, no two instances of an `ItemStack` will ever satisfy `Objects#equal` (in the default implementation from `Object`), even if their contents are identical since their identities are different. This is even more pronounced for `ItemScrollData.Mutable#remove`, which copies the stack before removing it; thus, it will _never_ match an existing stack in the list.

To work around this limitation, we now manually iterate the list and use `ItemStack#isSameItem`  (mirroring the same method used in `ItemScrollData#contains`) to compare against the target stack, and removing by index. Using the index for removal means the `ArrayList` won't have to iterate again in its own code to find the object's index (as it does in `ArrayList#remove(Object)`).

Some comments have been added to make it clear why that loop exists, to help out in the future when debugging this area of code.

Alternatively, `List#removeIf` could be used instead of the loop to save on code, but it brings with the side-effect that all instances in the list matching the stack is removed, rather than the first instance which is the behavior of `List#remove`.