### PR TITLE
feat: SourceUtil multi-provider take

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/wrapped_caster/TileCaster.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/wrapped_caster/TileCaster.java
@@ -74,7 +74,7 @@ public class TileCaster implements IWrappedCaster{
     public void expendMana(int totalCost) {
         if (tile instanceof BasicSpellTurretTile spellTurretTile) {
             if (spellTurretTile.getManaCost() <= 0) return;
-            SourceUtil.takeSourceWithParticles(tile.getBlockPos(), tile.getLevel(), 10, spellTurretTile.getManaCost());
+            SourceUtil.takeSourceMultipleWithParticles(tile.getBlockPos(), tile.getLevel(), 10, spellTurretTile.getManaCost());
         }
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
@@ -113,6 +113,14 @@ public class SourceUtil {
         return takeSourceMultipleWithParticles(pos, pos, level, range, source);
     }
 
+    public static @Nullable ISpecialSourceProvider takeSourceWithParticles(BlockPos pos, BlockPos particlesTo, Level level, int range, int source){
+        ISpecialSourceProvider result = takeSource(pos, level, range, source);
+        if(result != null && level instanceof ServerLevel serverLevel){
+            EntityFollowProjectile.spawn(serverLevel, result.getCurrentPos(), particlesTo);
+        }
+        return result;
+    }
+
     /**
      * @param pos Position around which to find source providers
      * @param level Level to find source providers in
@@ -126,14 +134,6 @@ public class SourceUtil {
             for (ISpecialSourceProvider provider : result) {
                 EntityFollowProjectile.spawn(serverLevel, provider.getCurrentPos(), particlesTo);
             }
-        }
-        return result;
-    }
-
-    public static @Nullable ISpecialSourceProvider takeSourceWithParticles(BlockPos pos, BlockPos particlesTo, Level level, int range, int source){
-        ISpecialSourceProvider result = takeSource(pos, level, range, source);
-        if(result != null && level instanceof ServerLevel serverLevel){
-            EntityFollowProjectile.spawn(serverLevel, result.getCurrentPos(), particlesTo);
         }
         return result;
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
@@ -41,6 +41,17 @@ public class SourceUtil {
         return posList;
     }
 
+    public static @Nullable ISpecialSourceProvider takeSource(BlockPos pos, Level level, int range, int source){
+        List<ISpecialSourceProvider> providers = canTakeSource(pos, level, range);
+        for(ISpecialSourceProvider provider : providers){
+            if(provider.getSource().getSource() >= source){
+                provider.getSource().removeSource(source);
+                return provider;
+            }
+        }
+        return null;
+    }
+
     /**
      * @param pos Position around which to find source providers
      * @param level Level to find source providers in
@@ -48,7 +59,7 @@ public class SourceUtil {
      * @param source How much source to extract
      * @return List of all the providers extracted from, or null if there was not enough total source.
      */
-    public static @Nullable List<ISpecialSourceProvider> takeSource(BlockPos pos, Level level, int range, int source) {
+    public static @Nullable List<ISpecialSourceProvider> takeSourceMultiple(BlockPos pos, Level level, int range, int source) {
         List<ISpecialSourceProvider> providers = canTakeSource(pos, level, range);
         Multimap<ISpecialSourceProvider, Integer> potentialRefunds = Multimaps.newMultimap(new HashMap<>(), ArrayList::new);
 
@@ -87,14 +98,7 @@ public class SourceUtil {
         return new ArrayList<>(potentialRefunds.keys());
     }
 
-    /**
-     * @param pos Position around which to find source providers
-     * @param level Level to find source providers in
-     * @param range Range to check around `pos`
-     * @param source How much source to extract
-     * @return List of all the providers extracted from, or null if there was not enough total source.
-     */
-    public static @Nullable List<ISpecialSourceProvider> takeSourceWithParticles(BlockPos pos, Level level, int range, int source){
+    public static @Nullable ISpecialSourceProvider takeSourceWithParticles(BlockPos pos, Level level, int range, int source){
         return takeSourceWithParticles(pos, pos, level, range, source);
     }
 
@@ -105,8 +109,19 @@ public class SourceUtil {
      * @param source How much source to extract
      * @return List of all the providers extracted from, or null if there was not enough total source.
      */
-    public static @Nullable List<ISpecialSourceProvider> takeSourceWithParticles(BlockPos pos, BlockPos particlesTo, Level level, int range, int source){
-        List<ISpecialSourceProvider> result = takeSource(pos, level, range, source);
+    public static @Nullable List<ISpecialSourceProvider> takeSourceMultipleWithParticles(BlockPos pos, Level level, int range, int source){
+        return takeSourceMultipleWithParticles(pos, pos, level, range, source);
+    }
+
+    /**
+     * @param pos Position around which to find source providers
+     * @param level Level to find source providers in
+     * @param range Range to check around `pos`
+     * @param source How much source to extract
+     * @return List of all the providers extracted from, or null if there was not enough total source.
+     */
+    public static @Nullable List<ISpecialSourceProvider> takeSourceMultipleWithParticles(BlockPos pos, BlockPos particlesTo, Level level, int range, int source){
+        List<ISpecialSourceProvider> result = takeSourceMultiple(pos, level, range, source);
         if(result != null && level instanceof ServerLevel serverLevel){
             for (ISpecialSourceProvider provider : result) {
                 EntityFollowProjectile.spawn(serverLevel, provider.getCurrentPos(), particlesTo);
@@ -115,6 +130,13 @@ public class SourceUtil {
         return result;
     }
 
+    public static @Nullable ISpecialSourceProvider takeSourceWithParticles(BlockPos pos, BlockPos particlesTo, Level level, int range, int source){
+        ISpecialSourceProvider result = takeSource(pos, level, range, source);
+        if(result != null && level instanceof ServerLevel serverLevel){
+            EntityFollowProjectile.spawn(serverLevel, result.getCurrentPos(), particlesTo);
+        }
+        return result;
+    }
 
     /**
      * Searches for nearby mana jars that have enough mana.

--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
@@ -41,6 +41,15 @@ public class SourceUtil {
         return posList;
     }
 
+    /**
+     * @deprecated Use {@link SourceUtil#takeSourceMultiple}
+     * @param pos Position around which to find source providers
+     * @param level Level to find source providers in
+     * @param range Range to check around `pos`
+     * @param source How much source to extract
+     * @return Provider that was extracted from, or null if none had enough source.
+     */
+    @Deprecated(forRemoval = true)
     public static @Nullable ISpecialSourceProvider takeSource(BlockPos pos, Level level, int range, int source){
         List<ISpecialSourceProvider> providers = canTakeSource(pos, level, range);
         for(ISpecialSourceProvider provider : providers){
@@ -95,7 +104,15 @@ public class SourceUtil {
 
         return new ArrayList<>(potentialRefunds.keys());
     }
-
+    /**
+     * @deprecated Use {@link SourceUtil#takeSourceMultipleWithParticles(BlockPos, Level, int, int)}
+     * @param pos Position around which to find source providers
+     * @param level Level to find source providers in
+     * @param range Range to check around `pos`
+     * @param source How much source to extract
+     * @return Provider that was extracted from, or null if none had enough source.
+     */
+    @Deprecated(forRemoval = true)
     public static @Nullable ISpecialSourceProvider takeSourceWithParticles(BlockPos pos, Level level, int range, int source){
         return takeSourceWithParticles(pos, pos, level, range, source);
     }
@@ -111,6 +128,15 @@ public class SourceUtil {
         return takeSourceMultipleWithParticles(pos, pos, level, range, source);
     }
 
+    /**
+     * @deprecated Use {@link SourceUtil#takeSourceMultipleWithParticles(BlockPos, BlockPos, Level, int, int)}
+     * @param pos Position around which to find source providers
+     * @param level Level to find source providers in
+     * @param range Range to check around `pos`
+     * @param source How much source to extract
+     * @return Provider that was extracted from, or null if none had enough source.
+     */
+    @Deprecated(forRemoval = true)
     public static @Nullable ISpecialSourceProvider takeSourceWithParticles(BlockPos pos, BlockPos particlesTo, Level level, int range, int source){
         ISpecialSourceProvider result = takeSource(pos, level, range, source);
         if(result != null && level instanceof ServerLevel serverLevel){

--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
@@ -83,16 +83,20 @@ public class SourceUtil {
                 return List.of(provider);
             }
 
+            if (needed <= 0) {
+                continue;
+            }
+
             int initial = sourceTile.getSource();
             int available = Math.min(needed, initial);
             int after = sourceTile.removeSource(available);
-            if (needed > 0 && initial > after) {
+            if (initial > after) {
                 int extracted = initial - after;
                 needed -= extracted;
                 takenFrom.put(provider, extracted);
             }
 
-            // We can't break even if needed < 0 as there may still be a Creative Source Jar in the list
+            // We can't break even if needed <= 0 as there may still be a Creative Source Jar in the list
         }
 
         if (needed > 0) {

--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
@@ -70,13 +70,13 @@ public class SourceUtil {
      */
     public static @Nullable List<ISpecialSourceProvider> takeSourceMultiple(BlockPos pos, Level level, int range, int source) {
         List<ISpecialSourceProvider> providers = canTakeSource(pos, level, range);
-        Multimap<ISpecialSourceProvider, Integer> potentialRefunds = Multimaps.newMultimap(new HashMap<>(), ArrayList::new);
+        Multimap<ISpecialSourceProvider, Integer> takenFrom = Multimaps.newMultimap(new HashMap<>(), ArrayList::new);
 
         int needed = source;
         for (ISpecialSourceProvider provider : providers) {
             ISourceTile sourceTile = provider.getSource();
             if (sourceTile instanceof CreativeSourceJarTile) {
-                for (Map.Entry<ISpecialSourceProvider, Integer> entry : potentialRefunds.entries()) {
+                for (Map.Entry<ISpecialSourceProvider, Integer> entry : takenFrom.entries()) {
                     entry.getKey().getSource().addSource(entry.getValue());
                 }
 
@@ -89,20 +89,20 @@ public class SourceUtil {
             if (needed > 0 && initial > after) {
                 int extracted = initial - after;
                 needed -= extracted;
-                potentialRefunds.put(provider, extracted);
+                takenFrom.put(provider, extracted);
             }
 
             // We can't braek even if needed < 0 as there may still be a Creative Source Jar in the list
         }
 
         if (needed > 0) {
-            for (Map.Entry<ISpecialSourceProvider, Integer> entry : potentialRefunds.entries()) {
+            for (Map.Entry<ISpecialSourceProvider, Integer> entry : takenFrom.entries()) {
                 entry.getKey().getSource().addSource(entry.getValue());
             }
             return null;
         }
 
-        return new ArrayList<>(potentialRefunds.keys());
+        return new ArrayList<>(takenFrom.keys());
     }
     /**
      * @deprecated Use {@link SourceUtil#takeSourceMultipleWithParticles(BlockPos, Level, int, int)}

--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
@@ -92,7 +92,7 @@ public class SourceUtil {
                 takenFrom.put(provider, extracted);
             }
 
-            // We can't braek even if needed < 0 as there may still be a Creative Source Jar in the list
+            // We can't break even if needed < 0 as there may still be a Creative Source Jar in the list
         }
 
         if (needed > 0) {

--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SourceUtil.java
@@ -83,9 +83,7 @@ public class SourceUtil {
                 potentialRefunds.put(provider, extracted);
             }
 
-            if (needed <= 0) {
-                break;
-            }
+            // We can't braek even if needed < 0 as there may still be a Creative Source Jar in the list
         }
 
         if (needed > 0) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/BasicSpellTurretTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/BasicSpellTurretTile.java
@@ -69,7 +69,7 @@ public class BasicSpellTurretTile extends ModdedTile implements ITooltipProvider
         if (spellCaster.getSpell().isEmpty() || !(this.level instanceof ServerLevel level))
             return;
         int manaCost = getManaCost();
-        if (manaCost > 0 && SourceUtil.takeSourceWithParticles(pos, level, 10, manaCost) == null)
+        if (manaCost > 0 && SourceUtil.takeSourceMultipleWithParticles(pos, level, 10, manaCost) == null)
             return;
         Networking.sendToNearbyClient(level, pos, new PacketOneShotAnimation(pos));
         Position iposition = BasicSpellTurret.getDispensePosition(pos, level.getBlockState(pos).getValue(BasicSpellTurret.FACING));

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/DrygmyTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/DrygmyTile.java
@@ -71,7 +71,7 @@ public class DrygmyTile extends SummoningTile implements ITooltipProvider, IWand
                 refreshEntitiesAndBonus();
             }
 
-            if (level.getGameTime() % 80 == 0 && needsMana && SourceUtil.takeSourceWithParticles(worldPosition, level, 7, Config.DRYGMY_MANA_COST.get()) != null) {
+            if (level.getGameTime() % 80 == 0 && needsMana && SourceUtil.takeSourceMultipleWithParticles(worldPosition, level, 7, Config.DRYGMY_MANA_COST.get()) != null) {
                 this.needsMana = false;
                 updateBlock();
             }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/EnchantingApparatusTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/EnchantingApparatusTile.java
@@ -151,7 +151,7 @@ public class EnchantingApparatusTile extends SingleItemTile implements Container
         }
         IEnchantingRecipe recipe = this.getRecipe(catalyst, playerEntity);
         if (recipe.consumesSource())
-            SourceUtil.takeSourceWithParticles(worldPosition, level, 10, recipe.sourceCost());
+            SourceUtil.takeSourceMultipleWithParticles(worldPosition, level, 10, recipe.sourceCost());
         this.isCrafting = true;
         updateBlock();
         Networking.sendToNearbyClient(level, worldPosition, new PacketOneShotAnimation(worldPosition));

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ImbuementTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ImbuementTile.java
@@ -140,11 +140,13 @@ public class ImbuementTile extends AbstractSourceMachine implements Container, I
             if (!canAcceptSource(Math.min(200, cost)))
                 return;
 
-            ISpecialSourceProvider takePos = SourceUtil.takeSource(worldPosition, level, 2, Math.min(200, cost));
+            List<ISpecialSourceProvider> takePos = SourceUtil.takeSource(worldPosition, level, 2, Math.min(200, cost));
             if (takePos != null) {
                 this.addSource(transferRate);
-                EntityFlyingItem.spawn(worldPosition, serverLevel, takePos.getCurrentPos().above(), worldPosition)
-                        .withNoTouch().setDistanceAdjust(2f);
+                for (ISpecialSourceProvider provider : takePos) {
+                    EntityFlyingItem.spawn(worldPosition, serverLevel, provider.getCurrentPos().above(), worldPosition)
+                            .withNoTouch().setDistanceAdjust(2f);
+                }
 
                 if (!draining) {
                     draining = true;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ImbuementTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ImbuementTile.java
@@ -140,7 +140,7 @@ public class ImbuementTile extends AbstractSourceMachine implements Container, I
             if (!canAcceptSource(Math.min(200, cost)))
                 return;
 
-            List<ISpecialSourceProvider> takePos = SourceUtil.takeSource(worldPosition, level, 2, Math.min(200, cost));
+            List<ISpecialSourceProvider> takePos = SourceUtil.takeSourceMultiple(worldPosition, level, 2, Math.min(200, cost));
             if (takePos != null) {
                 this.addSource(transferRate);
                 for (ISpecialSourceProvider provider : takePos) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/PotionMelderTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/PotionMelderTile.java
@@ -72,7 +72,7 @@ public class PotionMelderTile extends ModdedTile implements GeoBlockEntity, ITic
             return;
         }
         if (!level.isClientSide && !hasSource && level.getGameTime() % 20 == 0) {
-            if (SourceUtil.takeSourceWithParticles(worldPosition, level, 5, Config.MELDER_SOURCE_COST.get()) != null) {
+            if (SourceUtil.takeSourceMultipleWithParticles(worldPosition, level, 5, Config.MELDER_SOURCE_COST.get()) != null) {
                 hasSource = true;
                 updateBlock();
             }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RitualBrazierTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RitualBrazierTile.java
@@ -152,7 +152,7 @@ public class RitualBrazierTile extends ModdedTile implements ITooltipProvider, G
             }
             if (ritual.consumesSource() && ritual.needsSourceNow()) {
                 int cost = ritual.getSourceCost();
-                if (SourceUtil.takeSourceWithParticles(getBlockPos(), getLevel(), 6, cost) != null) {
+                if (SourceUtil.takeSourceMultipleWithParticles(getBlockPos(), getLevel(), 6, cost) != null) {
                     ritual.setNeedsSource(false);
                     updateBlock();
                 } else {
@@ -172,7 +172,7 @@ public class RitualBrazierTile extends ModdedTile implements ITooltipProvider, G
     public boolean takeSource(){
         if (ritual.consumesSource() && ritual.needsSourceNow()) {
             int cost = ritual.getSourceCost();
-            if (SourceUtil.takeSourceWithParticles(getBlockPos(), getLevel(), 6, cost) != null) {
+            if (SourceUtil.takeSourceMultipleWithParticles(getBlockPos(), getLevel(), 6, cost) != null) {
                 ritual.setNeedsSource(false);
                 updateBlock();
                 return true;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RotatingTurretTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RotatingTurretTile.java
@@ -152,7 +152,7 @@ public class RotatingTurretTile extends BasicSpellTurretTile implements IWandabl
         if (spellCaster.getSpell().isEmpty() || !(level instanceof ServerLevel level))
             return;
         int manaCost = getManaCost();
-        if (manaCost > 0 && SourceUtil.takeSourceWithParticles(pos, level, 10, manaCost) == null)
+        if (manaCost > 0 && SourceUtil.takeSourceMultipleWithParticles(pos, level, 10, manaCost) == null)
             return;
         Networking.sendToNearbyClient(level, pos, new PacketOneShotAnimation(pos));
         Position iposition = RotatingSpellTurret.getDispensePosition(pos, this);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RuneTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RuneTile.java
@@ -138,7 +138,7 @@ public class RuneTile extends ModdedTile implements GeoBlockEntity, ITickable, I
             level.destroyBlock(this.worldPosition, false);
         }
         if (!level.isClientSide) {
-            List<ISpecialSourceProvider> provider = SourceUtil.takeSourceWithParticles(worldPosition, level, 10, 100);
+            List<ISpecialSourceProvider> provider = SourceUtil.takeSourceMultipleWithParticles(worldPosition, level, 10, 100);
             if (provider != null) {
                 this.isCharged = true;
                 level.setBlockAndUpdate(worldPosition, level.getBlockState(worldPosition).cycle(RuneBlock.POWERED));

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RuneTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RuneTile.java
@@ -138,7 +138,7 @@ public class RuneTile extends ModdedTile implements GeoBlockEntity, ITickable, I
             level.destroyBlock(this.worldPosition, false);
         }
         if (!level.isClientSide) {
-            ISpecialSourceProvider provider = SourceUtil.takeSourceWithParticles(worldPosition, level, 10, 100);
+            List<ISpecialSourceProvider> provider = SourceUtil.takeSourceWithParticles(worldPosition, level, 10, 100);
             if (provider != null) {
                 this.isCharged = true;
                 level.setBlockAndUpdate(worldPosition, level.getBlockState(worldPosition).cycle(RuneBlock.POWERED));

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/WhirlisprigTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/WhirlisprigTile.java
@@ -78,7 +78,7 @@ public class WhirlisprigTile extends SummoningTile implements GeoBlockEntity {
             if (ticksToNextEval <= 0)
                 evaluateGrove();
 
-            if (level.getGameTime() % 60 == 0 && progress >= Config.WHIRLISPRIG_MAX_PROGRESS.get() && SourceUtil.takeSourceWithParticles(worldPosition, level, 5, Config.WHIRLISPRIG_SOURCE_COST.get()) != null) {
+            if (level.getGameTime() % 60 == 0 && progress >= Config.WHIRLISPRIG_MAX_PROGRESS.get() && SourceUtil.takeSourceMultipleWithParticles(worldPosition, level, 5, Config.WHIRLISPRIG_SOURCE_COST.get()) != null) {
                 this.progress = 0;
                 DropDistribution<BlockState> blockDropDistribution = new DropDistribution<>(genTable);
                 int numDrops = getDropsByDiversity() + 3;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/WixieCauldronTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/WixieCauldronTile.java
@@ -80,7 +80,7 @@ public class WixieCauldronTile extends SummoningTile implements ITooltipProvider
             return;
         }
 
-        if (!hasSource && level.getGameTime() % 5 == 0 && SourceUtil.takeSourceWithParticles(worldPosition, level, 6, 50) != null) {
+        if (!hasSource && level.getGameTime() % 5 == 0 && SourceUtil.takeSourceMultipleWithParticles(worldPosition, level, 6, 50) != null) {
             this.hasSource = true;
             level.setBlockAndUpdate(worldPosition, level.getBlockState(worldPosition).setValue(WixieCauldron.FILLED, true));
             setChanged();

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/statemachine/alakarkinos/DecideCrabActionState.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/statemachine/alakarkinos/DecideCrabActionState.java
@@ -21,7 +21,7 @@ public class DecideCrabActionState extends CrabState {
         }
 
         if(alakarkinos.needSource() && alakarkinos.level.getGameTime() % 20 == 0){
-            var result = SourceUtil.takeSourceWithParticles(alakarkinos.getHome(), alakarkinos.blockPosition().above(), alakarkinos.level, 5, Config.ALAKARKINOS_SOURCE_COST.get());
+            var result = SourceUtil.takeSourceMultipleWithParticles(alakarkinos.getHome(), alakarkinos.blockPosition().above(), alakarkinos.level, 5, Config.ALAKARKINOS_SOURCE_COST.get());
 
             if(result != null ){
                 alakarkinos.setNeedSource(false);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/WarpScroll.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/WarpScroll.java
@@ -46,7 +46,7 @@ public class WarpScroll extends ModItem {
             && data.canTeleportWithDim(entity.getCommandSenderWorld().dimension().location().toString())
             && SourceUtil.hasSourceNearby(entity.blockPosition(), entity.getCommandSenderWorld(), 10, 9000)
             && BlockRegistry.PORTAL_BLOCK.get().trySpawnPortal(entity.getCommandSenderWorld(), entity.blockPosition(), data, displayName)
-            && SourceUtil.takeSourceWithParticles(entity.blockPosition(), entity.getCommandSenderWorld(), 10, 9000) != null) {
+            && SourceUtil.takeSourceMultipleWithParticles(entity.blockPosition(), entity.getCommandSenderWorld(), 10, 9000) != null) {
             BlockPos pos = entity.blockPosition();
             ServerLevel world = (ServerLevel) entity.getCommandSenderWorld();
             world.sendParticles(ParticleTypes.PORTAL, pos.getX(), pos.getY() + 1.0, pos.getZ(),


### PR DESCRIPTION
allows SourceUtil#takeSource to extract from multiple ISpecialSourceProviders in order to reach the desired amount. Also short circuits if a Creative Source Jar is found.

split of #1555 