### PR TITLE
Fix: Update PortalFrameTester.java (Closes #1063)

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/PortalFrameTester.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/PortalFrameTester.java
@@ -34,7 +34,7 @@ public abstract class PortalFrameTester {
         }
         blockPos = blockPos.relative(axis1, -(offsetX - 1));
         int offsetY = 1;
-        while (blockPos.getZ() - offsetY > 0 && validStateInsidePortal(world.getBlockState(blockPos.relative(axis2, -offsetY)))) {
+        while (validStateInsidePortal(world.getBlockState(blockPos.relative(axis2, -offsetY)))) {
             offsetY++;
             if (offsetY > 20) return null;
         }


### PR DESCRIPTION
Fixes horizontal portals getting destroyed by block updates and horizontal portal generation. Horizontal portals will no longer break when receiving a block update. Horizontal portals can now be generated by throwing the scroll anywhere inside the frame and not just on the northernmost line of blocks.