### PR TITLE
Knockback and Burst/Wall adjustments.

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityWallSpell.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityWallSpell.java
@@ -1,6 +1,5 @@
 package com.hollingsworth.arsnouveau.common.entity;
 
-import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.client.particle.ParticleLineData;
 import com.hollingsworth.arsnouveau.client.particle.ParticleUtil;
 import com.hollingsworth.arsnouveau.common.lib.EntityTags;
@@ -19,6 +18,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.*;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
@@ -175,7 +175,7 @@ public class EntityWallSpell extends EntityProjectileSpell {
     }
 
     @Override
-    public EntityType<?> getType() {
+    public @NotNull EntityType<?> getType() {
         return ModEntities.WALL_SPELL.get();
     }
 
@@ -200,7 +200,7 @@ public class EntityWallSpell extends EntityProjectileSpell {
     }
 
     public float getAoe() {
-        return 3 + entityData.get(AOE);
+        return (this.isSensitive() ? 1 : 3) + entityData.get(AOE);
     }
 
     public void setLanded(boolean landed) {
@@ -223,7 +223,7 @@ public class EntityWallSpell extends EntityProjectileSpell {
         entityData.set(DIRECTION, direction);
     }
 
-    public Direction getDirection() {
+    public @NotNull Direction getDirection() {
         return entityData.get(DIRECTION);
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBurst.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBurst.java
@@ -48,11 +48,14 @@ public class EffectBurst extends AbstractEffect {
         makeSphere(rayTraceResult.getEntity().blockPosition(), world, shooter, spellStats, spellContext, resolver);
     }
 
-    public void makeSphere(BlockPos center, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver){
+    public void makeSphere(BlockPos center, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         if (spellContext.getRemainingSpell().isEmpty()) return;
 
-        int radius = (int) (1 + spellStats.getAoeMultiplier());
-        Predicate<Double> sphere = spellStats.hasBuff(AugmentDampen.INSTANCE) ? (distance) -> distance <= radius + 0.5 && distance >= radius - 0.5 : (distance) -> (distance <= radius + 0.5);
+        // like linger, reduce the radius if sensitive
+        int radius = (int) spellStats.getAoeMultiplier() + (spellStats.isSensitive() ? 1 : 3);
+
+        Predicate<Double> sphere = spellStats.hasBuff(AugmentDampen.INSTANCE) ? distance -> distance <= radius + 0.5 && distance >= radius - 0.5 : distance -> distance <= radius + 0.5;
+
         if (spellStats.isSensitive()) {
             for (BlockPos pos : BlockPos.withinManhattan(center, radius, radius, radius)) {
                 if (sphere.test(BlockUtil.distanceFromCenter(pos, center))) {


### PR DESCRIPTION
Add Extract to knockback to apply motion relative to caster pos instead of caster look, works best with orbit and burst.

Uniform wall and burst sensitive aoe adjustment to be the same as linger (1 aoe bonus if sensitive and 3 aoe bonus if not)