### PR TITLE
fix: radial selection fires quickcast bound to mouse buttons

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/radial_menu/GuiRadialMenu.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/radial_menu/GuiRadialMenu.java
@@ -246,13 +246,12 @@ public class GuiRadialMenu<T> extends Screen {
         return super.keyPressed(key, scanCode, modifiers);
     }
 
-    @Override
-    public boolean mouseClicked(double p_mouseClicked_1_, double p_mouseClicked_3_, int p_mouseClicked_5_) {
+    public void onMouseClick(){
+        java.lang.System.out.println("Mouse Clicked in GUI!");
         if (this.selectedItem != -1) {
             radialMenu.setCurrentSlot(selectedItem);
             minecraft.player.closeContainer();
         }
-        return true;
     }
 
     public void drawSlice(

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/radial_menu/GuiRadialMenu.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/radial_menu/GuiRadialMenu.java
@@ -246,11 +246,13 @@ public class GuiRadialMenu<T> extends Screen {
         return super.keyPressed(key, scanCode, modifiers);
     }
 
-    public void onMouseClick(){
+    @Override
+    public boolean mouseClicked(double p_mouseClicked_1_, double p_mouseClicked_3_, int p_mouseClicked_5_) {
         if (this.selectedItem != -1) {
             radialMenu.setCurrentSlot(selectedItem);
             minecraft.player.closeContainer();
         }
+        return super.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_);
     }
 
     public void drawSlice(

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/radial_menu/GuiRadialMenu.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/radial_menu/GuiRadialMenu.java
@@ -247,7 +247,6 @@ public class GuiRadialMenu<T> extends Screen {
     }
 
     public void onMouseClick(){
-        java.lang.System.out.println("Mouse Clicked in GUI!");
         if (this.selectedItem != -1) {
             radialMenu.setCurrentSlot(selectedItem);
             minecraft.player.closeContainer();

--- a/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
@@ -135,7 +135,13 @@ public class KeyHandler {
 
         if (MINECRAFT.player == null || event.getAction() != 1)
             return;
-        if (MINECRAFT.screen == null || MINECRAFT.screen instanceof GuiRadialMenu)
+        if (MINECRAFT.screen instanceof GuiRadialMenu<?> screen) {
+            screen.onMouseClick();
+            return;
+        }
+        if (Minecraft.getInstance().screen != null && Minecraft.getInstance().screen.isPauseScreen())
+            return;
+        if (MINECRAFT.screen == null)
             checkKeysPressed(event.getButton());
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
@@ -136,7 +136,7 @@ public class KeyHandler {
         if (MINECRAFT.player == null || event.getAction() != 1)
             return;
         if (MINECRAFT.screen instanceof GuiRadialMenu<?> screen) {
-            screen.onMouseClick();
+            screen.mouseClicked(0, 0, 0);
             return;
         }
         if (MINECRAFT.screen == null)

--- a/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
@@ -139,8 +139,6 @@ public class KeyHandler {
             screen.onMouseClick();
             return;
         }
-        if (Minecraft.getInstance().screen != null && Minecraft.getInstance().screen.isPauseScreen())
-            return;
         if (MINECRAFT.screen == null)
             checkKeysPressed(event.getButton());
     }


### PR DESCRIPTION
This PR fixes an issue where binding LMB to a quickcast slot immediately fires the bound spell upon selecting an option in the selection HUD.