### PR TITLE
fix: invalidate lectern caps when connected inventories change

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/StorageLecternTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/StorageLecternTile.java
@@ -282,6 +282,7 @@ public class StorageLecternTile extends ModdedTile implements MenuProvider, ITic
         }
         this.mainLecternPos = storedPos.immutable();
         this.connectedInventories = new ArrayList<>();
+        this.invalidateCapabilities();
         PortUtil.sendMessage(playerEntity, Component.translatable("ars_nouveau.storage.lectern_chained", storedPos.getX(), storedPos.getY(), storedPos.getZ()));
         updateBlock();
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/StorageLecternTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/StorageLecternTile.java
@@ -252,12 +252,14 @@ public class StorageLecternTile extends ModdedTile implements MenuProvider, ITic
         if (this.connectedInventories.contains(storedPos)) {
             PortUtil.sendMessage(playerEntity, Component.translatable("ars_nouveau.storage.removed"));
             this.connectedInventories.remove(storedPos);
+            this.invalidateCapabilities();
         } else {
             if (this.connectedInventories.size() >= this.getMaxConnectedInventories()) {
                 PortUtil.sendMessage(playerEntity, Component.translatable("ars_nouveau.storage.too_many"));
                 return;
             }
             this.connectedInventories.add(storedPos.immutable());
+            this.invalidateCapabilities();
             PortUtil.sendMessage(playerEntity, Component.translatable("ars_nouveau.storage.from_set"));
         }
         this.mainLecternPos = null;
@@ -515,6 +517,7 @@ public class StorageLecternTile extends ModdedTile implements MenuProvider, ITic
             CompoundTag c = list.getCompound(i);
             connectedInventories.add(new BlockPos(c.getInt("x"), c.getInt("y"), c.getInt("z")));
         }
+        this.invalidateCapabilities();
         mainLecternPos = null;
         if (compound.contains("mainLecternPos")) {
             mainLecternPos = BlockPos.of(compound.getLong("mainLecternPos"));


### PR DESCRIPTION
fixes issues with other mods reading the lectern (e.g. ae2 storage bus)