### PR TITLE
Retrieve `RegistryAccess` directly from the server for caster tome registry

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/ArsNouveau.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/ArsNouveau.java
@@ -1,6 +1,5 @@
 package com.hollingsworth.arsnouveau;
 
-
 import com.hollingsworth.arsnouveau.api.registry.*;
 import com.hollingsworth.arsnouveau.api.ritual.DispenserRitualBehavior;
 import com.hollingsworth.arsnouveau.client.registry.ClientHandler;
@@ -23,7 +22,6 @@ import com.hollingsworth.arsnouveau.setup.proxy.ServerProxy;
 import com.hollingsworth.arsnouveau.setup.registry.*;
 import com.hollingsworth.arsnouveau.setup.reward.Rewards;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ComposterBlock;
 import net.minecraft.world.level.block.DispenserBlock;
@@ -125,7 +123,7 @@ public class ArsNouveau {
 
         NeoForge.EVENT_BUS.addListener((ServerStartedEvent e) -> {
             GenericRecipeRegistry.reloadAll(e.getServer().getRecipeManager());
-            CasterTomeRegistry.reloadTomeData(e.getServer().getRecipeManager(), e.getServer().getLevel(Level.OVERWORLD));
+            CasterTomeRegistry.reloadTomeData(e.getServer().getRecipeManager(), e.getServer().registryAccess());
             BuddingConversionRegistry.reloadBuddingConversionRecipes(e.getServer().getRecipeManager());
             ScryRitualRegistry.reloadScryRitualRecipes(e.getServer().getRecipeManager());
         });

--- a/src/main/java/com/hollingsworth/arsnouveau/api/registry/CasterTomeRegistry.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/registry/CasterTomeRegistry.java
@@ -6,7 +6,6 @@ import com.hollingsworth.arsnouveau.setup.registry.RecipeRegistry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeManager;
-import net.minecraft.world.level.Level;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,12 +19,11 @@ public class CasterTomeRegistry {
         return Collections.unmodifiableList(TOME_DATA);
     }
 
-    public static List<RecipeHolder<CasterTomeData>> reloadTomeData(RecipeManager recipeManager, Level level){
+    public static List<RecipeHolder<CasterTomeData>> reloadTomeData(RecipeManager recipeManager, RegistryAccess access){
         var recipes = recipeManager.getAllRecipesFor(RecipeRegistry.CASTER_TOME_TYPE.get());
         DungeonLootTables.CASTER_TOMES = new ArrayList<>();
         TOME_DATA = new ArrayList<>();
         TOME_DATA.addAll(recipes);
-        RegistryAccess access = level.registryAccess();
         recipes.forEach(tome -> DungeonLootTables.CASTER_TOMES.add(() -> tome.value().getResultItem(access)));
         return TOME_DATA;
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
@@ -111,7 +111,7 @@ public class EventHandler {
                     @Override
                     public void tick(ServerTickEvent serverTickEvent) {
                         GenericRecipeRegistry.reloadAll(serverTickEvent.getServer().getRecipeManager());
-                        CasterTomeRegistry.reloadTomeData(serverTickEvent.getServer().getRecipeManager(), serverTickEvent.getServer().getLevel(Level.OVERWORLD));
+                        CasterTomeRegistry.reloadTomeData(serverTickEvent.getServer().getRecipeManager(), serverTickEvent.getServer().registryAccess());
                         BuddingConversionRegistry.reloadBuddingConversionRecipes(serverTickEvent.getServer().getRecipeManager());
                         AlakarkinosConversionRegistry.reloadAlakarkinosRecipes(serverTickEvent.getServer().getRecipeManager());
                         ScryRitualRegistry.reloadScryRitualRecipes(serverTickEvent.getServer().getRecipeManager());


### PR DESCRIPTION
Rather than trying to make use of a specific Overworld level from the started server for `CasterTomeRegistry` and doing so only for a `RegistryAccess`, it would make more sense for the latter to be retrieved directly from the started server itself independently of any level.

In situations such as when using the test server provided by NeoForge and ModDevGradle for unit testing, this prevents any such test runs from crashing and hanging due to the fact that the test server doesn't have any levels to speak of and returns `null` when trying to retrieve them, which up until now was never checked or accounted for.