### PR TITLE
fix: remove amethyst scry augment due to lack of #c:storage_blocks/amethyst

### DIFF
--- a/src/generated/resources/data/ars_nouveau/recipe/scry_ritual/amethyst_gems.json
+++ b/src/generated/resources/data/ars_nouveau/recipe/scry_ritual/amethyst_gems.json
@@ -1,5 +1,0 @@
-{
-  "type": "ars_nouveau:scry_ritual",
-  "augment": "c:gems/amethyst",
-  "highlight": "c:storage_blocks/amethyst"
-}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/ScryRitualProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/ScryRitualProvider.java
@@ -39,7 +39,6 @@ public class ScryRitualProvider extends SimpleDataProvider{
         for (String ore : defaultOres) {
             addForgeOreRecipe(ore);
         }
-        recipes.add(new ScryRecipeWrapper(ArsNouveau.prefix( "amethyst_gems"), forgeItemTag("gems/amethyst"), forgeBlockTag("storage_blocks/amethyst")));
     }
 
     private void addForgeOreRecipe(String ore) {


### PR DESCRIPTION
this was a broken recipe entry and didnt provide much value due to the existence of the dowsing rod