### PR TITLE
fix: apparatus crafting and rune recharge 1 tick longer than they should be

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/EnchantingApparatusTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/EnchantingApparatusTile.java
@@ -1,6 +1,5 @@
 package com.hollingsworth.arsnouveau.common.block.tile;
 
-import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import com.hollingsworth.arsnouveau.api.block.IPedestalMachine;
 import com.hollingsworth.arsnouveau.api.util.SourceUtil;
 import com.hollingsworth.arsnouveau.client.particle.*;
@@ -91,7 +90,7 @@ public class EnchantingApparatusTile extends SingleItemTile implements Container
             counter += 1;
         }
 
-        if (counter > craftingLength) {
+        if (counter >= craftingLength) {
             counter = 0;
 
             if (this.isCrafting) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RuneTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RuneTile.java
@@ -130,8 +130,7 @@ public class RuneTile extends ModdedTile implements GeoBlockEntity, ITickable, I
         if (level == null)
             return;
         if (!level.isClientSide) {
-            if (ticksUntilCharge > 0) {
-                ticksUntilCharge -= 1;
+            if (--ticksUntilCharge > 0) {
                 return;
             }
         }


### PR DESCRIPTION
this PR is made with the assumption that these are indeed unintentional, which seems likely since the raw numbers used indicate intent that apparatus should take 210 ticks to craft and runes should take 40 ticks to recharge, rather than the 211 and 41 ticks that can be observed.