### PR TITLE
fix: rotate when warping to unloaded (client-side) chunks

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/PortalTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/PortalTile.java
@@ -138,12 +138,13 @@ public class PortalTile extends ModdedTile implements ITickable, ITooltipProvide
             if((targetWorld.getBlockState(target).getBlock() instanceof PortalBlock)){
                 return entity;
             }
-            entity.teleportTo(target.getX() + 0.5, target.getY(), target.getZ() + 0.5);
             var rotX = rotationVec != null ? rotationVec.x : entity.getXRot();
             var rotY = rotationVec != null ? rotationVec.y : entity.getYRot();
+            Networking.sendToNearbyClient(targetWorld, entity, new PacketWarpPosition(entity.getId(),target.getX() + 0.5, target.getY(), target.getZ() + 0.5, rotX, rotY));
+            entity.teleportTo(target.getX() + 0.5, target.getY(), target.getZ() + 0.5);
             entity.setXRot(rotX);
             entity.setYRot(rotY);
-            Networking.sendToNearbyClient(targetWorld, entity, new PacketWarpPosition(entity.getId(),target.getX() + 0.5, target.getY(), target.getZ() + 0.5, rotX, rotY));
+
             if (!entity.getPassengers().isEmpty()) {
                 //Force re-apply any passengers so that players don't get "stuck" outside what they may be riding
                 ((ServerChunkCache) entity.getCommandSenderWorld().getChunkSource()).broadcast(entity, new ClientboundSetPassengersPacket(entity));

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/WarpScroll.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/WarpScroll.java
@@ -75,11 +75,13 @@ public class WarpScroll extends ModItem {
                 return InteractionResultHolder.fail(stack);
             }
             BlockPos pos = data.pos().get();
-            player.teleportTo(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5);
             Vec2 rotation = data.rotation();
+
+            Networking.sendToNearbyClient(world, player, new PacketWarpPosition(player.getId(),pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5, rotation.x, rotation.y));
+            player.teleportTo(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5);
             player.setXRot(rotation.x);
             player.setYRot(rotation.y);
-            Networking.sendToNearbyClient(world, player, new PacketWarpPosition(player.getId(),pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5, rotation.x, rotation.y));
+
             serverLevel.sendParticles(ParticleTypes.PORTAL, pos.getX(), pos.getY() + 1.0, pos.getZ(),
                     10, (world.random.nextDouble() - 0.5D) * 2.0D, -world.random.nextDouble(), (world.random.nextDouble() - 0.5D) * 2.0D, 0.1f);
             world.playSound(null, pos, SoundEvents.ILLUSIONER_CAST_SPELL, SoundSource.NEUTRAL, 1.0f, 1.0f);


### PR DESCRIPTION
just sends the packet before setting position so that the warped player also gets it