### PR TITLE
fix: bug in pathfinding preventing buncles from pathing upward

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -1072,13 +1072,13 @@ public abstract class AbstractPathJob implements Callable<Path> {
         double parentMaxY = parentY + parent.pos.below().getY();
         final double targetMaxY = target.getCollisionShape(world, pos).max(Direction.Axis.Y) + pos.getY();
         if (targetMaxY - parentMaxY < MAX_JUMP_HEIGHT) {
-            return pos.getY() + (isSmall ? 0 : 1);
+            return pos.getY() + 1;
         }
         if (target.getBlock() instanceof StairBlock
                 && parentY - HALF_A_BLOCK < MAX_JUMP_HEIGHT
                 && target.getValue(StairBlock.HALF) == Half.BOTTOM
                 && getXZFacing(parent.pos, pos) == target.getValue(StairBlock.FACING)) {
-            return pos.getY() + (isSmall ? 0 : 1);
+            return pos.getY() + 1;
         }
         return -100;
     }


### PR DESCRIPTION
Fixing a bug in starbuncle's pathfinding that prevented the algorithm from walking up when checking path to goal. 

Before:

![2025-02-08 10-18-46(1)](https://github.com/user-attachments/assets/afd902f5-82a9-4c34-b20b-7355efb6da4d)


After:

![2025-02-08 10-16-04(1)](https://github.com/user-attachments/assets/c4d6ac0d-d2d0-4120-9367-3a67d6da4b38)


The function `handleTargetNotPassable` should be returning the height of the block we are jumping to, so at the end it should return `pos.getY() + 1` even for small mobs.

Resolves a long standing issue: https://github.com/baileyholl/Ars-Nouveau/issues/1215