### PR TITLE
fix: windburst stuff

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWindburst.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWindburst.java
@@ -48,7 +48,7 @@ public class EffectWindburst extends AbstractEffect {
         }
 
         world.explode(
-                dummyWindCharge,
+                spellStats.isSensitive() ? shooter : dummyWindCharge,
                 null,
                 new SimpleExplosionDamageCalculator(
                         true, false, Optional.of(1.22f + (float) (spellStats.getAmpMultiplier() * this.AMP_VALUE.getAsDouble())), BuiltInRegistries.BLOCK.getTag(BlockTags.BLOCKS_WIND_CHARGE_EXPLOSIONS).map(Function.identity())

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWindburst.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWindburst.java
@@ -15,7 +15,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.windcharge.WindCharge;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.SimpleExplosionDamageCalculator;
-import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.ModConfigSpec;
@@ -38,18 +37,10 @@ public class EffectWindburst extends AbstractEffect {
     public void onResolve(HitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         super.onResolve(rayTraceResult, world, shooter, spellStats, spellContext, resolver);
 
-        double x, y, z;
-        if (rayTraceResult instanceof BlockHitResult bhr) {
-            var pos = bhr.getBlockPos();
-            x = pos.getX();
-            y = pos.getY();
-            z = pos.getZ();
-        } else {
-            var loc = rayTraceResult.getLocation();
-            x = loc.x;
-            y = loc.y;
-            z = loc.z;
-        }
+        var loc = rayTraceResult.getLocation();
+        double x = loc.x;
+        double y = loc.y;
+        double z = loc.z;
 
         var dummyWindCharge = new WindCharge(world, x, y, z, Vec3.ZERO);
         if (spellStats.isSensitive()) {


### PR DESCRIPTION
fixes block resolving causing windburst to spawn inside caster
sets explosion source to dummy wind charge so fall damage from impulse is negated 