### PR TITLE
feat: sort preference cached sorting

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/item/inv/InventoryManager.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/item/inv/InventoryManager.java
@@ -300,7 +300,7 @@ public class InventoryManager {
                 .filter(filterableItemHandler -> includeInvalid || filterableItemHandler.getHighestPreference(stack) != ItemScroll.SortPref.INVALID)
                 .collect(Collectors.toCollection(ArrayList::new));
         /// Sort by highest pref first
-        CachedSort.sortByCachedIntKey(filtered, (FilterableItemHandler o) -> -o.getHighestPreference(stack).ordinal());
+        CachedSort.sortByCachedIntKey(filtered, (FilterableItemHandler o) -> ~o.getHighestPreference(stack).ordinal());
         return filtered;
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/api/item/inv/InventoryManager.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/item/inv/InventoryManager.java
@@ -3,6 +3,7 @@ package com.hollingsworth.arsnouveau.api.item.inv;
 import com.hollingsworth.arsnouveau.api.spell.wrapped_caster.IWrappedCaster;
 import com.hollingsworth.arsnouveau.api.util.InvUtil;
 import com.hollingsworth.arsnouveau.common.items.ItemScroll;
+import com.hollingsworth.arsnouveau.common.util.CachedSort;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
@@ -299,7 +300,7 @@ public class InventoryManager {
                 .filter(filterableItemHandler -> includeInvalid || filterableItemHandler.getHighestPreference(stack) != ItemScroll.SortPref.INVALID)
                 .collect(Collectors.toCollection(ArrayList::new));
         /// Sort by highest pref first
-        filtered.sort((o1, o2) -> o2.getHighestPreference(stack).ordinal() - o1.getHighestPreference(stack).ordinal());
+        CachedSort.sortByCachedIntKey(filtered, (FilterableItemHandler o) -> -o.getHighestPreference(stack).ordinal());
         return filtered;
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/util/CachedSort.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/util/CachedSort.java
@@ -6,27 +6,20 @@ import java.util.List;
 import java.util.function.ToIntFunction;
 
 public class CachedSort {
-    record IntIntPair(int left, int right) implements Comparable<IntIntPair> {
-        @Override
-        public int compareTo(IntIntPair o) {
-            return Integer.compare(this.left, o.left);
-        }
-    }
-
     public static <T> void sortByCachedIntKey(List<T> list, ToIntFunction<T> mappingFunction) {
-        IntIntPair[] indices = new IntIntPair[list.size()];
+        long[] indices = new long[list.size()];
 
         for (int i = 0; i < list.size(); i++) {
-            indices[i] = new IntIntPair(mappingFunction.applyAsInt(list.get(i)), i);
+            indices[i] = ((long) mappingFunction.applyAsInt(list.get(i)) << 32L) + i;
         }
 
         Arrays.sort(indices);
         for (int i = 0; i < list.size(); i++) {
-            var index = indices[i].right;
+            int index = (int) (indices[i] & 0xFFFF_FFFFL);
             while (index < i) {
-                index = indices[index].right;
+                index = (int) (indices[index] & 0xFFFF_FFFFL);
             }
-            indices[i] = new IntIntPair(indices[i].left, index);
+            indices[i] = (indices[i] << 32L) + (index & 0xFFFF_FFFFL);
             Collections.swap(list, i, index);
         }
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/util/CachedSort.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/util/CachedSort.java
@@ -1,0 +1,33 @@
+package com.hollingsworth.arsnouveau.common.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.ToIntFunction;
+
+public class CachedSort {
+    record IntIntPair(int left, int right) implements Comparable<IntIntPair> {
+        @Override
+        public int compareTo(IntIntPair o) {
+            return Integer.compare(this.left, o.left);
+        }
+    }
+
+    public static <T> void sortByCachedIntKey(List<T> list, ToIntFunction<T> mappingFunction) {
+        IntIntPair[] indices = new IntIntPair[list.size()];
+
+        for (int i = 0; i < list.size(); i++) {
+            indices[i] = new IntIntPair(mappingFunction.applyAsInt(list.get(i)), i);
+        }
+
+        Arrays.sort(indices);
+        for (int i = 0; i < list.size(); i++) {
+            var index = indices[i].right;
+            while (index < i) {
+                index = indices[index].right;
+            }
+            indices[i] = new IntIntPair(indices[i].left, index);
+            Collections.swap(list, i, index);
+        }
+    }
+}


### PR DESCRIPTION
credits to rust's [`alloc::slice::sort_by_cached_key`](https://doc.rust-lang.org/src/alloc/slice.rs.html#413-416)