### PR TITLE
feat: use dropCustomDeathLoot rather than die to spawn helper charms

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/Alakarkinos.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/Alakarkinos.java
@@ -176,15 +176,14 @@ public class Alakarkinos extends PathfinderMob implements GeoEntity, IDispellabl
         }
     }
 
-
     @Override
-    public void die(DamageSource source) {
+    protected void dropCustomDeathLoot(ServerLevel level, DamageSource damageSource, boolean recentlyHit) {
+        super.dropCustomDeathLoot(level, damageSource, recentlyHit);
         if (!level.isClientSide && tamed) {
             ItemStack stack = new ItemStack(ItemsRegistry.ALAKARKINOS_CHARM);
             stack.set(DataComponentRegistry.PERSISTENT_FAMILIAR_DATA, createCharmData());
             level.addFreshEntity(new ItemEntity(level, getX(), getY(), getZ(), stack));
         }
-        super.die(source);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/AmethystGolem.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/AmethystGolem.java
@@ -229,7 +229,8 @@ public class AmethystGolem extends PathfinderMob implements GeoEntity, IDispella
     }
 
     @Override
-    public void die(DamageSource source) {
+    protected void dropCustomDeathLoot(ServerLevel level, DamageSource damageSource, boolean recentlyHit) {
+        super.dropCustomDeathLoot(level, damageSource, recentlyHit);
         if (!level.isClientSide) {
             ItemStack stack = new ItemStack(ItemsRegistry.AMETHYST_GOLEM_CHARM.get());
             stack.set(DataComponentRegistry.PERSISTENT_FAMILIAR_DATA, createCharmData());
@@ -237,7 +238,6 @@ public class AmethystGolem extends PathfinderMob implements GeoEntity, IDispella
             if (this.getMainHandItem() != null)
                 level.addFreshEntity(new ItemEntity(level, getX(), getY(), getZ(), this.getMainHandItem()));
         }
-        super.die(source);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityBookwyrm.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityBookwyrm.java
@@ -288,14 +288,13 @@ public class EntityBookwyrm extends FlyingMob implements IDispellable, ITooltipP
     }
 
     @Override
-    public void die(DamageSource source) {
+    protected void dropCustomDeathLoot(ServerLevel level, DamageSource damageSource, boolean recentlyHit) {
+        super.dropCustomDeathLoot(level, damageSource, recentlyHit);
         if (!level.isClientSide) {
             ItemStack stack = new ItemStack(ItemsRegistry.BOOKWYRM_CHARM.get());
             stack.set(DataComponentRegistry.PERSISTENT_FAMILIAR_DATA, createCharmData());
             level.addFreshEntity(new ItemEntity(level, getX(), getY(), getZ(), stack));
         }
-
-        super.die(source);
     }
 
     public static AttributeSupplier.Builder attributes() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityDrygmy.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityDrygmy.java
@@ -103,13 +103,13 @@ public class EntityDrygmy extends PathfinderMob implements GeoEntity, ITooltipPr
     }
 
     @Override
-    public void die(DamageSource source) {
+    protected void dropCustomDeathLoot(ServerLevel level, DamageSource damageSource, boolean recentlyHit) {
+        super.dropCustomDeathLoot(level, damageSource, recentlyHit);
         if (!level.isClientSide && isTamed()) {
             ItemStack stack = new ItemStack(ItemsRegistry.DRYGMY_CHARM);
             stack.set(DataComponentRegistry.PERSISTENT_FAMILIAR_DATA, createCharmData());
             level.addFreshEntity(new ItemEntity(level, getX(), getY(), getZ(), stack));
         }
-        super.die(source);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityWixie.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityWixie.java
@@ -210,13 +210,13 @@ public class EntityWixie extends AbstractFlyingCreature implements GeoEntity, IA
     }
 
     @Override
-    public void die(DamageSource source) {
+    protected void dropCustomDeathLoot(ServerLevel level, DamageSource damageSource, boolean recentlyHit) {
+        super.dropCustomDeathLoot(level, damageSource, recentlyHit);
         if (!level.isClientSide) {
             ItemStack stack = new ItemStack(ItemsRegistry.WIXIE_CHARM);
             stack.set(DataComponentRegistry.PERSISTENT_FAMILIAR_DATA, createCharmData());
             level.addFreshEntity(new ItemEntity(level, getX(), getY(), getZ(), stack));
         }
-        super.die(source);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/Starbuncle.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/Starbuncle.java
@@ -435,11 +435,11 @@ public class Starbuncle extends PathfinderMob implements GeoEntity, IDecoratable
     }
 
     @Override
-    public void die(@NotNull DamageSource source) {
+    protected void dropCustomDeathLoot(ServerLevel level, DamageSource damageSource, boolean recentlyHit) {
+        super.dropCustomDeathLoot(level, damageSource, recentlyHit);
         if (!level.isClientSide && isTamed()) {
             dropData();
         }
-        super.die(source);
     }
 
     public void dropData() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/Whirlisprig.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/Whirlisprig.java
@@ -309,13 +309,13 @@ public class Whirlisprig extends AbstractFlyingCreature implements GeoEntity, IT
     }
 
     @Override
-    public void die(DamageSource source) {
+    protected void dropCustomDeathLoot(ServerLevel level, DamageSource damageSource, boolean recentlyHit) {
+        super.dropCustomDeathLoot(level, damageSource, recentlyHit);
         if (!level.isClientSide && isTamed()) {
             ItemStack stack = new ItemStack(ItemsRegistry.WHIRLISPRIG_CHARM);
             stack.set(DataComponentRegistry.PERSISTENT_FAMILIAR_DATA, this.createCharmData());
             level.addFreshEntity(new ItemEntity(level, getX(), getY(), getZ(), stack));
         }
-        super.die(source);
     }
 
     //MOJANG MAKES THIS SO CURSED WHAT THE HECK


### PR DESCRIPTION
should prevent scavenger from apotheosis or other similar things duping charms