### PR TITLE
feat: codec cleanup

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/perk/PerkSlot.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/perk/PerkSlot.java
@@ -15,13 +15,13 @@ public record PerkSlot(ResourceLocation id, int value, DocAssets.BlitInfo icon) 
         this(id, value, DocAssets.ICON_THREAD_TIER3);
     }
     public static final Codec<PerkSlot> CODEC = RecordCodecBuilder.create((instance) -> instance.group(
-            ResourceLocation.CODEC.fieldOf("id").forGetter((PerkSlot::id)),
-            Codec.INT.fieldOf("value").forGetter((PerkSlot::value))
+            ResourceLocation.CODEC.fieldOf("id").forGetter(PerkSlot::id),
+            Codec.INT.fieldOf("value").forGetter(PerkSlot::value)
     ).apply(instance, PerkSlot::new));
 
-    public static Codec<List<PerkSlot>> LIST_CODEC = Codec.list(CODEC);
+    public static final Codec<List<PerkSlot>> LIST_CODEC = Codec.list(CODEC);
 
-    public static Codec<List<List<PerkSlot>>> TIERED_LIST_CODEC = Codec.list(LIST_CODEC);
+    public static final Codec<List<List<PerkSlot>>> TIERED_LIST_CODEC = Codec.list(LIST_CODEC);
 
     public static ConcurrentHashMap<ResourceLocation, PerkSlot> PERK_SLOTS = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/hollingsworth/arsnouveau/api/sound/SpellSound.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/sound/SpellSound.java
@@ -14,11 +14,11 @@ import java.util.Objects;
 
 public class SpellSound {
 
-    public static MapCodec<SpellSound> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+    public static final MapCodec<SpellSound> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             ResourceLocation.CODEC.fieldOf("id").forGetter(SpellSound::getId)
     ).apply(instance, SpellSoundRegistry::get));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, SpellSound> STREAM = StreamCodec.composite(
+    public static final StreamCodec<RegistryFriendlyByteBuf, SpellSound> STREAM = StreamCodec.composite(
             ResourceLocation.STREAM_CODEC,
             SpellSound::getId,
             SpellSoundRegistry::get

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/AlakarkinosRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/AlakarkinosRecipe.java
@@ -1,6 +1,7 @@
 package com.hollingsworth.arsnouveau.common.crafting.recipes;
 
 import com.hollingsworth.arsnouveau.api.registry.AlakarkinosConversionRegistry.LootDrop;
+import com.hollingsworth.arsnouveau.common.util.ANCodecs;
 import com.hollingsworth.arsnouveau.setup.registry.RecipeRegistry;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
@@ -56,7 +57,13 @@ public record AlakarkinosRecipe(Block input, ResourceKey<LootTable> table, int w
                 LootDrops.CODEC.optionalFieldOf("drops").forGetter(AlakarkinosRecipe::drops)
         ).apply(instance, AlakarkinosRecipe::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, AlakarkinosRecipe> STREAM_CODEC = ByteBufCodecs.fromCodecWithRegistries(CODEC.codec());
+        public static final StreamCodec<RegistryFriendlyByteBuf, AlakarkinosRecipe> STREAM_CODEC = StreamCodec.composite(
+                ANCodecs.streamRegistry(BuiltInRegistries.BLOCK), AlakarkinosRecipe::input,
+                ResourceKey.streamCodec(Registries.LOOT_TABLE), AlakarkinosRecipe::table,
+                ByteBufCodecs.INT, AlakarkinosRecipe::weight,
+                ByteBufCodecs.optional(LootDrops.STREAM_CODEC), AlakarkinosRecipe::drops,
+                AlakarkinosRecipe::new
+        );
 
         public static final StreamCodec<RegistryFriendlyByteBuf, AlakarkinosRecipe> STREAM = StreamCodec.of(
                 AlakarkinosRecipe.Serializer::toNetwork, AlakarkinosRecipe.Serializer::fromNetwork

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/ArmorUpgradeRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/ArmorUpgradeRecipe.java
@@ -11,6 +11,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -93,13 +94,18 @@ public class ArmorUpgradeRecipe extends EnchantingApparatusRecipe implements ITe
     }
 
     public static class Serializer implements RecipeSerializer<ArmorUpgradeRecipe> {
-        public static MapCodec<ArmorUpgradeRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        public static final MapCodec<ArmorUpgradeRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
                 Ingredient.CODEC.listOf().fieldOf("pedestalItems").forGetter(ArmorUpgradeRecipe::pedestalItems),
                 Codec.INT.fieldOf("sourceCost").forGetter(ArmorUpgradeRecipe::sourceCost),
                 Codec.INT.fieldOf("tier").forGetter(ArmorUpgradeRecipe::tier)
         ).apply(instance, ArmorUpgradeRecipe::new));
 
-        public static StreamCodec<RegistryFriendlyByteBuf, ArmorUpgradeRecipe> STREAM_CODEC = CheatSerializer.create(CODEC);
+        public static final StreamCodec<RegistryFriendlyByteBuf, ArmorUpgradeRecipe> STREAM_CODEC = StreamCodec.composite(
+                Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list()), ArmorUpgradeRecipe::pedestalItems,
+                ByteBufCodecs.INT, ArmorUpgradeRecipe::sourceCost,
+                ByteBufCodecs.INT, ArmorUpgradeRecipe::tier,
+                ArmorUpgradeRecipe::new
+        );
 
         @Override
         public @NotNull MapCodec<ArmorUpgradeRecipe> codec() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/BuddingConversionRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/BuddingConversionRecipe.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.common.crafting.recipes;
 
+import com.hollingsworth.arsnouveau.common.util.ANCodecs;
 import com.hollingsworth.arsnouveau.setup.registry.RecipeRegistry;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -42,7 +43,11 @@ public record BuddingConversionRecipe(Block input, Block result) implements Spec
                 BuiltInRegistries.BLOCK.byNameCodec().fieldOf("result").forGetter(BuddingConversionRecipe::result)
         ).apply(instance, BuddingConversionRecipe::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, BuddingConversionRecipe> STREAM = CheatSerializer.create(CODEC);
+        public static final StreamCodec<RegistryFriendlyByteBuf, BuddingConversionRecipe> STREAM = StreamCodec.composite(
+                ANCodecs.streamRegistry(BuiltInRegistries.BLOCK), BuddingConversionRecipe::input,
+                ANCodecs.streamRegistry(BuiltInRegistries.BLOCK), BuddingConversionRecipe::result,
+                BuddingConversionRecipe::new
+        );
 
         @Override
         public MapCodec<BuddingConversionRecipe> codec() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/EnchantingApparatusRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/EnchantingApparatusRecipe.java
@@ -140,7 +140,7 @@ public class EnchantingApparatusRecipe implements IEnchantingRecipe {
 
     public static class Serializer implements RecipeSerializer<EnchantingApparatusRecipe> {
 
-        public static MapCodec<EnchantingApparatusRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        public static final MapCodec<EnchantingApparatusRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
                 Ingredient.CODEC.fieldOf("reagent").forGetter(EnchantingApparatusRecipe::reagent),
                 ItemStack.CODEC.fieldOf("result").forGetter(EnchantingApparatusRecipe::result),
                 Ingredient.CODEC.listOf().fieldOf("pedestalItems").forGetter(EnchantingApparatusRecipe::pedestalItems),
@@ -148,7 +148,7 @@ public class EnchantingApparatusRecipe implements IEnchantingRecipe {
                 Codec.BOOL.fieldOf("keepNbtOfReagent").forGetter(EnchantingApparatusRecipe::keepNbtOfReagent)
         ).apply(instance, EnchantingApparatusRecipe::new));
 
-        public static StreamCodec<RegistryFriendlyByteBuf, EnchantingApparatusRecipe> STREAM_CODEC = StreamCodec.composite(
+        public static final StreamCodec<RegistryFriendlyByteBuf, EnchantingApparatusRecipe> STREAM_CODEC = StreamCodec.composite(
                 Ingredient.CONTENTS_STREAM_CODEC,
                 EnchantingApparatusRecipe::reagent,
                 ItemStack.STREAM_CODEC,

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/EnchantmentRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/EnchantmentRecipe.java
@@ -129,14 +129,14 @@ public class EnchantmentRecipe extends EnchantingApparatusRecipe {
 
     public static class Serializer implements RecipeSerializer<EnchantmentRecipe> {
 
-        public static MapCodec<EnchantmentRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        public static final MapCodec<EnchantmentRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
                 Ingredient.CODEC.listOf().fieldOf("pedestalItems").forGetter(EnchantmentRecipe::pedestalItems),
                 ResourceKey.codec(Registries.ENCHANTMENT).fieldOf("enchantment").forGetter(EnchantmentRecipe::enchantmentKey),
                 Codec.INT.fieldOf("level").forGetter(EnchantmentRecipe::enchantLevel),
                 Codec.INT.fieldOf("sourceCost").forGetter(EnchantmentRecipe::sourceCost)
         ).apply(instance, EnchantmentRecipe::new));
 
-        public static StreamCodec<RegistryFriendlyByteBuf, EnchantmentRecipe> STREAM_CODEC = StreamCodec.composite(
+        public static final StreamCodec<RegistryFriendlyByteBuf, EnchantmentRecipe> STREAM_CODEC = StreamCodec.composite(
                 Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.collection(ArrayList::new)),
                 EnchantmentRecipe::pedestalItems,
                 ResourceKey.streamCodec(Registries.ENCHANTMENT),

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/ReactiveEnchantmentRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/ReactiveEnchantmentRecipe.java
@@ -12,6 +12,7 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -76,7 +77,11 @@ public class ReactiveEnchantmentRecipe extends EnchantmentRecipe {
                 Codec.INT.fieldOf("sourceCost").forGetter(ReactiveEnchantmentRecipe::sourceCost)
         ).apply(instance, ReactiveEnchantmentRecipe::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, ReactiveEnchantmentRecipe> STREAM = CheatSerializer.create(CODEC);
+        public static final StreamCodec<RegistryFriendlyByteBuf, ReactiveEnchantmentRecipe> STREAM = StreamCodec.composite(
+                Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list()), ReactiveEnchantmentRecipe::pedestalItems,
+                ByteBufCodecs.INT, ReactiveEnchantmentRecipe::sourceCost,
+                ReactiveEnchantmentRecipe::new
+        );
 
         @Override
         public @NotNull MapCodec<ReactiveEnchantmentRecipe> codec() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/ScryRitualRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/ScryRitualRecipe.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.common.crafting.recipes;
 
+import com.hollingsworth.arsnouveau.common.util.ANCodecs;
 import com.hollingsworth.arsnouveau.setup.registry.RecipeRegistry;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -37,7 +38,11 @@ public record ScryRitualRecipe(TagKey<Item> augment, TagKey<Block> highlight) im
                 TagKey.codec(Registries.BLOCK).fieldOf("highlight").forGetter(ScryRitualRecipe::highlight)
         ).apply(instance, ScryRitualRecipe::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, ScryRitualRecipe> STREAM_CODEC = CheatSerializer.create(CODEC);
+        public static final StreamCodec<RegistryFriendlyByteBuf, ScryRitualRecipe> STREAM_CODEC = StreamCodec.composite(
+                ANCodecs.streamTagKey(Registries.ITEM), ScryRitualRecipe::augment,
+                ANCodecs.streamTagKey(Registries.BLOCK), ScryRitualRecipe::highlight,
+                ScryRitualRecipe::new
+        );
 
         @Override
         public MapCodec<ScryRitualRecipe> codec() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/SpellWriteRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/SpellWriteRecipe.java
@@ -14,6 +14,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -91,7 +92,11 @@ public class SpellWriteRecipe extends EnchantingApparatusRecipe implements IText
                 Codec.INT.fieldOf("sourceCost").forGetter(SpellWriteRecipe::sourceCost)
         ).apply(instance, SpellWriteRecipe::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, SpellWriteRecipe> STREAM = CheatSerializer.create(CODEC);
+        public static final StreamCodec<RegistryFriendlyByteBuf, SpellWriteRecipe> STREAM = StreamCodec.composite(
+                Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list()), SpellWriteRecipe::pedestalItems,
+                ByteBufCodecs.INT, SpellWriteRecipe::sourceCost,
+                SpellWriteRecipe::new
+        );
 
         @Override
         public @NotNull MapCodec<SpellWriteRecipe> codec() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/SummonRitualRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/SummonRitualRecipe.java
@@ -4,18 +4,24 @@ import com.hollingsworth.arsnouveau.setup.registry.RecipeRegistry;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.StringRepresentable;
 import net.minecraft.util.random.Weight;
 import net.minecraft.util.random.WeightedEntry;
 import net.minecraft.util.random.WeightedRandomList;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.crafting.SingleRecipeInput;
 import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.network.codec.NeoForgeStreamCodecs;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -33,6 +39,13 @@ public class SummonRitualRecipe implements SpecialSingleInputRecipe {
         this.mobSource = source;
         this.count = count;
         this.mobs = mobs;
+    }
+
+    public SummonRitualRecipe(Ingredient augment, MobSource source, int count, List<WeightedMobType> mobs) {
+        this.augment = augment;
+        this.mobSource = source;
+        this.count = count;
+        this.mobs = WeightedRandomList.create(mobs);
     }
 
     public SummonRitualRecipe(Ingredient augment, String source, int count, List<WeightedMobType> mobs) {
@@ -74,12 +87,18 @@ public class SummonRitualRecipe implements SpecialSingleInputRecipe {
 
         public static final MapCodec<SummonRitualRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
                 Ingredient.CODEC.fieldOf("augment").forGetter(r -> r.augment),
-                Codec.STRING.fieldOf("mobSource").fieldOf("source").forGetter(r -> r.mobSource.toString()),
+                StringRepresentable.fromEnum(MobSource::values).fieldOf("mobSource").fieldOf("source").forGetter(r -> r.mobSource),
                 Codec.INT.fieldOf("count").forGetter(r -> r.count),
                 Codec.list(WeightedMobType.CODEC.codec()).fieldOf("mobs").forGetter(r -> r.mobs.unwrap())
         ).apply(instance, SummonRitualRecipe::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, SummonRitualRecipe> STREAM_CODEC = CheatSerializer.create(CODEC);
+        public static final StreamCodec<RegistryFriendlyByteBuf, SummonRitualRecipe> STREAM_CODEC = StreamCodec.composite(
+                Ingredient.CONTENTS_STREAM_CODEC, r -> r.augment,
+                NeoForgeStreamCodecs.enumCodec(MobSource.class), r -> r.mobSource,
+                ByteBufCodecs.INT, r -> r.count,
+                WeightedMobType.STREAM_CODEC.apply(ByteBufCodecs.list()), r -> r.mobs.unwrap(),
+                SummonRitualRecipe::new
+        );
 
         @Override
         public MapCodec<SummonRitualRecipe> codec() {
@@ -98,16 +117,25 @@ public class SummonRitualRecipe implements SpecialSingleInputRecipe {
      * @param mob    The mob to spawn
      * @param weight If there is more than one mob in the list, this is the chance that this mob will be selected
      */
-    public record WeightedMobType(ResourceLocation mob, int weight) implements WeightedEntry {
+    public record WeightedMobType(ResourceKey<EntityType<?>> mob, int weight) implements WeightedEntry {
+        public WeightedMobType(ResourceLocation mob, int weight) {
+            this(ResourceKey.create(Registries.ENTITY_TYPE, mob), weight);
+        }
 
         public WeightedMobType(ResourceLocation mob) {
             this(mob, 1);
         }
 
         public static final MapCodec<WeightedMobType> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-                ResourceLocation.CODEC.fieldOf("mob").forGetter(WeightedMobType::mob),
+                ResourceKey.codec(Registries.ENTITY_TYPE).fieldOf("mob").forGetter(WeightedMobType::mob),
                 Codec.INT.fieldOf("weight").forGetter(WeightedMobType::weight)
         ).apply(instance, WeightedMobType::new));
+
+        public static final StreamCodec<RegistryFriendlyByteBuf, WeightedMobType> STREAM_CODEC = StreamCodec.composite(
+                ResourceKey.streamCodec(Registries.ENTITY_TYPE), WeightedMobType::mob,
+                ByteBufCodecs.INT, WeightedMobType::weight,
+                WeightedMobType::new
+        );
 
         @Override
         public @NotNull Weight getWeight() {
@@ -115,9 +143,21 @@ public class SummonRitualRecipe implements SpecialSingleInputRecipe {
         }
     }
 
-    public enum MobSource {
-        CURRENT_BIOME,
-        MOB_LIST
+    public enum MobSource implements StringRepresentable {
+        CURRENT_BIOME("CURRENT_BIOME"),
+        MOB_LIST("MOB_LIST");
+
+        final String name;
+
+        MobSource(String name) {
+            this.name = name;
+        }
+
+        @NotNull
+        @Override
+        public String getSerializedName() {
+            return this.name;
+        }
     }
 
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/DispelEntityProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/DispelEntityProvider.java
@@ -37,7 +37,7 @@ public class DispelEntityProvider extends SimpleDataProvider{
     }
 
     protected void addEntries() {
-        recipes.add(new Wrapper(ArsNouveau.prefix("blaze_powder"), new DispelEntityRecipe(EntityType.BLAZE, EntityType.BLAZE.getDefaultLootTable().location(), new LootItemCondition[]{
+        recipes.add(new Wrapper(ArsNouveau.prefix("blaze_powder"), new DispelEntityRecipe(EntityType.BLAZE, EntityType.BLAZE.getDefaultLootTable(), new LootItemCondition[]{
                 LootItemEntityPropertyCondition.hasProperties(LootContext.EntityTarget.THIS, EntityPredicate.Builder.entity().flags(EntityFlagsPredicate.Builder.flags().setOnFire(true))).build()
         })));
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/CodexData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/CodexData.java
@@ -20,13 +20,13 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 public record CodexData(Optional<UUID> uuid, String playerName, List<ResourceLocation> glyphIds) implements TooltipProvider {
-    public static Codec<CodexData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<CodexData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             UUIDUtil.CODEC.optionalFieldOf("uuid").forGetter(CodexData::uuid),
             Codec.STRING.optionalFieldOf("playerName", "").forGetter(CodexData::playerName),
             Codec.list(ResourceLocation.CODEC).fieldOf("glyphIds").forGetter(CodexData::glyphIds)
     ).apply(instance, CodexData::new));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, CodexData> STREAM = StreamCodec.composite(
+    public static final StreamCodec<RegistryFriendlyByteBuf, CodexData> STREAM = StreamCodec.composite(
             UUIDUtil.STREAM_CODEC.apply(ByteBufCodecs::optional),
             CodexData::uuid,
             ByteBufCodecs.STRING_UTF8,

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/DominionWandData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/DominionWandData.java
@@ -21,14 +21,14 @@ public record DominionWandData(Optional<GlobalPos> storedPos, Optional<Direction
 
     public static final int NULL_ENTITY = -1;
 
-    public static Codec<DominionWandData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<DominionWandData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             GlobalPos.CODEC.optionalFieldOf("pos").forGetter(DominionWandData::storedPos),
             Direction.CODEC.optionalFieldOf("face").forGetter(DominionWandData::face),
             Codec.BOOL.fieldOf("strict").forGetter(DominionWandData::strict),
             Codec.INT.fieldOf("entityId").forGetter(DominionWandData::storedEntityId)
     ).apply(instance, DominionWandData::new));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, DominionWandData> STREAM = StreamCodec.composite(
+    public static final StreamCodec<RegistryFriendlyByteBuf, DominionWandData> STREAM = StreamCodec.composite(
             GlobalPos.STREAM_CODEC.apply(ByteBufCodecs::optional),
             DominionWandData::storedPos,
             Direction.STREAM_CODEC.apply(ByteBufCodecs::optional),

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/LightJarData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/LightJarData.java
@@ -11,12 +11,12 @@ import java.util.Objects;
 import java.util.Optional;
 
 public record LightJarData(Optional<BlockPos> pos, boolean enabled) {
-    public static Codec<LightJarData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<LightJarData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.optionalFieldOf("pos").forGetter(LightJarData::pos),
             Codec.BOOL.fieldOf("enabled").forGetter(LightJarData::enabled)
     ).apply(instance, LightJarData::new));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, LightJarData> STREAM_CODEC = StreamCodec.composite(BlockPos.STREAM_CODEC.apply(ByteBufCodecs::optional), LightJarData::pos, ByteBufCodecs.BOOL,LightJarData::enabled, LightJarData::new);
+    public static final StreamCodec<RegistryFriendlyByteBuf, LightJarData> STREAM_CODEC = StreamCodec.composite(BlockPos.STREAM_CODEC.apply(ByteBufCodecs::optional), LightJarData::pos, ByteBufCodecs.BOOL,LightJarData::enabled, LightJarData::new);
 
     public LightJarData() {
         this(Optional.empty(), false);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/MobJarData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/MobJarData.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 public record MobJarData(Optional<CompoundTag> entityTag, Optional<CompoundTag> extraDataTag){
-    public static Codec<MobJarData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<MobJarData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             CompoundTag.CODEC.optionalFieldOf("entity_tag").forGetter(MobJarData::entityTag),
             CompoundTag.CODEC.optionalFieldOf("extra_data_tag").forGetter(MobJarData::extraDataTag)
     ).apply(instance, MobJarData::new));
@@ -20,7 +20,7 @@ public record MobJarData(Optional<CompoundTag> entityTag, Optional<CompoundTag> 
         this(Optional.ofNullable(tag), Optional.ofNullable(extraTag));
     }
 
-    public static StreamCodec<RegistryFriendlyByteBuf, MobJarData> STREAM_CODEC = StreamCodec.composite(ByteBufCodecs.OPTIONAL_COMPOUND_TAG, MobJarData::entityTag, ByteBufCodecs.OPTIONAL_COMPOUND_TAG, MobJarData::extraDataTag, MobJarData::new);
+    public static final StreamCodec<RegistryFriendlyByteBuf, MobJarData> STREAM_CODEC = StreamCodec.composite(ByteBufCodecs.OPTIONAL_COMPOUND_TAG, MobJarData::entityTag, ByteBufCodecs.OPTIONAL_COMPOUND_TAG, MobJarData::extraDataTag, MobJarData::new);
 
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/MultiPotionContents.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/MultiPotionContents.java
@@ -16,13 +16,13 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public record MultiPotionContents(int charges, PotionContents contents, int maxUses) implements IPotionProvider {
-    public static Codec<MultiPotionContents> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<MultiPotionContents> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.INT.fieldOf("charges").forGetter(MultiPotionContents::charges),
             PotionContents.CODEC.fieldOf("contents").forGetter(MultiPotionContents::contents),
             Codec.INT.fieldOf("maxUses").forGetter(MultiPotionContents::maxUses)
     ).apply(instance, MultiPotionContents::new));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, MultiPotionContents> STREAM_CODEC = StreamCodec.composite(ByteBufCodecs.INT, MultiPotionContents::charges, PotionContents.STREAM_CODEC, MultiPotionContents::contents,ByteBufCodecs.INT, MultiPotionContents::maxUses, MultiPotionContents::new);
+    public static final StreamCodec<RegistryFriendlyByteBuf, MultiPotionContents> STREAM_CODEC = StreamCodec.composite(ByteBufCodecs.INT, MultiPotionContents::charges, PotionContents.STREAM_CODEC, MultiPotionContents::contents,ByteBufCodecs.INT, MultiPotionContents::maxUses, MultiPotionContents::new);
 
     public MultiPotionContents withCharges(int charges){
         return new MultiPotionContents(charges, contents, maxUses);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/PerkMap.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/PerkMap.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public record PerkMap(Map<IPerk, CompoundTag> map) {
-    public static Codec<PerkMap> CODEC =  Codec.unboundedMap(Codec.STRING, CompoundTag.CODEC).xmap((stringMap) ->{
+    public static final Codec<PerkMap> CODEC =  Codec.unboundedMap(Codec.STRING, CompoundTag.CODEC).xmap((stringMap) ->{
         var builder = ImmutableMap.<IPerk, CompoundTag>builder();
         stringMap.forEach((key, value) ->{
             if(key != null) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/PersistentFamiliarData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/PersistentFamiliarData.java
@@ -22,13 +22,13 @@ import java.util.function.Consumer;
 
 public class PersistentFamiliarData implements NBTComponent<PersistentFamiliarData>, TooltipProvider {
 
-    public static MapCodec<PersistentFamiliarData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+    public static final MapCodec<PersistentFamiliarData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
         ComponentSerialization.CODEC.optionalFieldOf("name", CommonComponents.EMPTY).forGetter(data -> data.name),
         Codec.STRING.optionalFieldOf("color", "").forGetter(data -> data.color),
         ItemStack.CODEC.optionalFieldOf("cosmetic", ItemStack.EMPTY).forGetter(data -> data.cosmetic)
     ).apply(instance, PersistentFamiliarData::new));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, PersistentFamiliarData>  STREAM_CODEC = StreamCodec.composite(ComponentSerialization.STREAM_CODEC, s -> s.name,
+    public static final StreamCodec<RegistryFriendlyByteBuf, PersistentFamiliarData>  STREAM_CODEC = StreamCodec.composite(ComponentSerialization.STREAM_CODEC, s -> s.name,
             ByteBufCodecs.STRING_UTF8, s -> s.color, ItemStack.OPTIONAL_STREAM_CODEC, s -> s.cosmetic, PersistentFamiliarData::new);
 
     private final Component name;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/PotionLauncherData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/PotionLauncherData.java
@@ -18,12 +18,12 @@ import java.util.Objects;
 
 public record PotionLauncherData(PotionContents renderData, int lastSlot) {
 
-    public static MapCodec<PotionLauncherData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+    public static final MapCodec<PotionLauncherData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
         PotionContents.CODEC.fieldOf("lastDataForRender").forGetter(PotionLauncherData::renderData),
         Codec.INT.fieldOf("lastSlot").forGetter(PotionLauncherData::lastSlot)
     ).apply(instance, PotionLauncherData::new));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, PotionLauncherData> STREAM = StreamCodec.composite(
+    public static final StreamCodec<RegistryFriendlyByteBuf, PotionLauncherData> STREAM = StreamCodec.composite(
             PotionContents.STREAM_CODEC,
             PotionLauncherData::renderData,
             ByteBufCodecs.INT,

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/PresentData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/PresentData.java
@@ -18,12 +18,12 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 public record PresentData(String name, Optional<UUID> uuid) implements TooltipProvider {
-    public static Codec<PresentData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<PresentData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.fieldOf("name").forGetter(PresentData::name),
             UUIDUtil.CODEC.optionalFieldOf("uuid").forGetter(PresentData::uuid)
     ).apply(instance, PresentData::new));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, PresentData> STREAM_CODEC = StreamCodec.composite(ByteBufCodecs.STRING_UTF8, PresentData::name, ByteBufCodecs.STRING_UTF8, p -> p.uuid().toString(), PresentData::new);
+    public static final StreamCodec<RegistryFriendlyByteBuf, PresentData> STREAM_CODEC = StreamCodec.composite(ByteBufCodecs.STRING_UTF8, PresentData::name, ByteBufCodecs.STRING_UTF8, p -> p.uuid().toString(), PresentData::new);
 
     public PresentData(String name, String uuid){
         this(name, Optional.ofNullable(uuid == null ? null : UUID.fromString(uuid)));

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/ReactiveCasterData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/ReactiveCasterData.java
@@ -13,9 +13,9 @@ import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.util.FakePlayer;
 
 public class ReactiveCasterData extends AbstractCaster<ReactiveCasterData> {
-    public static MapCodec<ReactiveCasterData> CODEC = SpellCaster.createCodec(ReactiveCasterData::new);
+    public static final MapCodec<ReactiveCasterData> CODEC = SpellCaster.createCodec(ReactiveCasterData::new);
 
-    public static StreamCodec<RegistryFriendlyByteBuf, ReactiveCasterData> STREAM_CODEC = createStream(ReactiveCasterData::new);
+    public static final StreamCodec<RegistryFriendlyByteBuf, ReactiveCasterData> STREAM_CODEC = createStream(ReactiveCasterData::new);
 
     @Override
     public MapCodec<ReactiveCasterData> codec() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/ScryPosData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/ScryPosData.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 public record ScryPosData(Optional<BlockPos> pos) {
-    public static Codec<ScryPosData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<ScryPosData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.optionalFieldOf("pos").forGetter(ScryPosData::pos)
     ).apply(instance, ScryPosData::new));
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/StackPerkHolder.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/StackPerkHolder.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  */
 public abstract class StackPerkHolder<T> implements IPerkHolder<T> {
 
-    public static Codec<IPerk> PERK_CODEC = RecordCodecBuilder.create((instance) -> instance.group(
+    public static final Codec<IPerk> PERK_CODEC = RecordCodecBuilder.create((instance) -> instance.group(
             ResourceLocation.CODEC.fieldOf("perk").forGetter(IPerk::getRegistryName)
     ).apply(instance, (name) -> PerkRegistry.getPerkMap().getOrDefault(name, StarbunclePerk.INSTANCE)));
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/data/StarbuncleCharmData.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/data/StarbuncleCharmData.java
@@ -33,7 +33,7 @@ import java.util.function.Consumer;
 
 public class StarbuncleCharmData implements NBTComponent<StarbuncleCharmData>, TooltipProvider {
 
-    public static MapCodec<StarbuncleCharmData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+    public static final MapCodec<StarbuncleCharmData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             ComponentSerialization.CODEC.optionalFieldOf("name").forGetter(StarbuncleCharmData::getName),
             Codec.STRING.optionalFieldOf("color", DyeColor.ORANGE.getName()).forGetter(StarbuncleCharmData::getColor),
 //            Block.CODEC.fieldOf("path").forGetter(data -> data.pathBlock),
@@ -45,7 +45,7 @@ public class StarbuncleCharmData implements NBTComponent<StarbuncleCharmData>, T
             Codec.STRING.optionalFieldOf("bio", "").forGetter(StarbuncleCharmData::getBio)
     ).apply(instance, StarbuncleCharmData::new));
 
-    public static StreamCodec<RegistryFriendlyByteBuf, StarbuncleCharmData> STREAM_CODEC = ANCodecs.composite(
+    public static final StreamCodec<RegistryFriendlyByteBuf, StarbuncleCharmData> STREAM_CODEC = ANCodecs.composite(
             ComponentSerialization.STREAM_CODEC.apply(ByteBufCodecs::optional),
             StarbuncleCharmData::getName,
             ByteBufCodecs.STRING_UTF8,

--- a/src/main/java/com/hollingsworth/arsnouveau/common/network/ClientToServerStoragePacket.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/network/ClientToServerStoragePacket.java
@@ -20,7 +20,7 @@ public class ClientToServerStoragePacket extends AbstractPacket{
     public static final StreamCodec<RegistryFriendlyByteBuf, ClientToServerStoragePacket> CODEC = StreamCodec.ofMember(ClientToServerStoragePacket::toBytes, ClientToServerStoragePacket::new);
 
     public record Data(Optional<String> search, Optional<InteractionData> interaction, Optional<List<List<ItemStack>>> craft) {
-        public static StreamCodec<RegistryFriendlyByteBuf, Data> STREAM_CODEC = StreamCodec.composite(
+        public static final StreamCodec<RegistryFriendlyByteBuf, Data> STREAM_CODEC = StreamCodec.composite(
                 ByteBufCodecs.optional(ByteBufCodecs.STRING_UTF8), Data::search,
                 ByteBufCodecs.optional(InteractionData.STREAM_CODEC), Data::interaction,
                 ByteBufCodecs.optional(ItemStack.OPTIONAL_STREAM_CODEC.apply(ByteBufCodecs.list()).apply(ByteBufCodecs.list(9))), Data::craft,
@@ -29,7 +29,7 @@ public class ClientToServerStoragePacket extends AbstractPacket{
     }
 
     public record InteractionData(boolean pullOne, Optional<StoredItemStack> stack, StorageTerminalMenu.SlotAction action) {
-        public static StreamCodec<RegistryFriendlyByteBuf, InteractionData> STREAM_CODEC = StreamCodec.composite(
+        public static final StreamCodec<RegistryFriendlyByteBuf, InteractionData> STREAM_CODEC = StreamCodec.composite(
                 ByteBufCodecs.BOOL, InteractionData::pullOne,
                 ByteBufCodecs.optional(StoredItemStack.STREAM), InteractionData::stack,
                 ByteBufCodecs.VAR_INT.map(i -> StorageTerminalMenu.SlotAction.values()[i], StorageTerminalMenu.SlotAction::ordinal), InteractionData::action,

--- a/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualAnimalSummoning.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualAnimalSummoning.java
@@ -8,12 +8,14 @@ import com.hollingsworth.arsnouveau.common.lib.RitualLib;
 import com.hollingsworth.arsnouveau.setup.registry.RecipeRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.random.WeightedEntry;
 import net.minecraft.util.random.WeightedRandomList;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -70,12 +72,20 @@ public class RitualAnimalSummoning extends AbstractRitual {
 
             Optional<? extends WeightedEntry> opt = mobs.getRandom(rand);
             opt.ifPresent(entry -> {
+                Entity mob = null;
                 if (entry instanceof MobSpawnSettings.SpawnerData spawnerData) {
-                    Entity mob = spawnerData.type.create(world);
-                    if (mob == null) return;
-                    summon(mob, summonPos);
-                    incrementProgress();
+                    mob = spawnerData.type.create(world);
+                } else if (entry instanceof SummonRitualRecipe.WeightedMobType weighted) {
+                    EntityType<?> type = BuiltInRegistries.ENTITY_TYPE.get(weighted.mob());
+                    mob = type.create(world);
                 }
+
+                if (mob == null) {
+                    return;
+                }
+
+                summon(mob, summonPos);
+                incrementProgress();
             });
 
             recipe.ifPresentOrElse(recipe -> {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/util/ANCodecs.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/util/ANCodecs.java
@@ -6,10 +6,15 @@ import com.mojang.datafixers.util.*;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.netty.buffer.ByteBuf;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.phys.Vec2;
 
 import java.util.Map;
@@ -18,7 +23,7 @@ import java.util.function.Function;
 
 public class ANCodecs {
 
-    public static Codec<Vec2> VEC2 = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<Vec2> VEC2 = RecordCodecBuilder.create(instance -> instance.group(
             Codec.FLOAT.fieldOf("x").forGetter(v -> v.x),
             Codec.FLOAT.fieldOf("y").forGetter(v -> v.y)
     ).apply(instance, Vec2::new));
@@ -336,4 +341,11 @@ public class ANCodecs {
         };
     }
 
+    public static <T> StreamCodec<ByteBuf, T> streamRegistry(Registry<T> registry) {
+        return ResourceLocation.STREAM_CODEC.map(registry::get, registry::getKey);
+    }
+
+    public static <T> StreamCodec<ByteBuf, TagKey<T>> streamTagKey(ResourceKey<? extends Registry<T>> registry) {
+        return ResourceLocation.STREAM_CODEC.map(r -> TagKey.create(registry, r), TagKey::location);
+    }
 }


### PR DESCRIPTION
remove uses of CheatSerializer, add helper methods for Registry items and TagKeys in ANCodecs, finalise all Codecs and StreamCodecs, replace some usages of ResourceLocation with ResourceKey.