### PR TITLE
Check if enchantment is disabled before using orThrow()

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/emi/EmiApparatusEnchantingRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/emi/EmiApparatusEnchantingRecipe.java
@@ -70,7 +70,7 @@ public class EmiApparatusEnchantingRecipe extends EmiEnchantingApparatusRecipe<E
             stack.remove(DataComponents.CUSTOM_NAME);
             if (stack.is(Items.ENCHANTED_BOOK)) {
                 stack = this.createEnchantedBook();
-            } else {
+            } else if (level != null) {
                 stack.enchant(HolderHelper.unwrap(level, recipe.enchantmentKey), recipe.enchantLevel);
             }
             return EmiStack.of(stack);
@@ -125,24 +125,26 @@ public class EmiApparatusEnchantingRecipe extends EmiEnchantingApparatusRecipe<E
 
         enchantableCache = new ArrayList<>();
         var level = Minecraft.getInstance().level;
-        var enchantment = HolderHelper.unwrap(level, recipe.enchantmentKey);
-        for (var item : BuiltInRegistries.ITEM) {
-            var stack = item.getDefaultInstance();
-            this.addName(stack);
-            if (stack.is(Items.ENCHANTED_BOOK)) {
-                stack = this.createEnchantedBook(this.recipe.enchantLevel - 1);
-            } else {
-                stack.enchant(enchantment, recipe.enchantLevel - 1);
-            }
-
-            var apparatus = new ApparatusRecipeInput(stack, List.of(), null);
-            try {
-                if (recipe.doesReagentMatch(apparatus, level, null)) {
-                    enchantableCache.add(stack);
+        if (level != null && level.holder(recipe.enchantmentKey).isPresent()) {
+            var enchantment = HolderHelper.unwrap(level, recipe.enchantmentKey);
+            for (var item : BuiltInRegistries.ITEM) {
+                var stack = item.getDefaultInstance();
+                this.addName(stack);
+                if (stack.is(Items.ENCHANTED_BOOK)) {
+                    stack = this.createEnchantedBook(this.recipe.enchantLevel - 1);
+                } else {
+                    stack.enchant(enchantment, recipe.enchantLevel - 1);
                 }
-            } catch (Exception ignored) {}
-        }
 
+                var apparatus = new ApparatusRecipeInput(stack, List.of(), null);
+                try {
+                    if (recipe.doesReagentMatch(apparatus, level, null)) {
+                        enchantableCache.add(stack);
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+        }
         return enchantableCache;
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/setup/registry/Documentation.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/setup/registry/Documentation.java
@@ -757,6 +757,7 @@ public class Documentation {
         for (var entry : enchantmentMap.entrySet()) {
             var enchantment = entry.getKey();
             var minMax = entry.getValue();
+            if (level.holder(enchantment).isEmpty()) break;
             DocEntryBuilder builder = new DocEntryBuilder(ENCHANTMENTS, enchantment.location().getPath())
                     .withIcon(Items.ENCHANTED_BOOK);
             builder.entryId = enchantment.location();


### PR DESCRIPTION
In some packs, enchantments like elemental's soulbound are disabled and might lead to components failing. It covers the reported failing points but more might be discovered in the future