### PR TITLE
fix: jarred entities dont save when jar is removed

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
@@ -136,6 +136,12 @@ public class MobJarTile extends ModdedTile implements ITickable, IDispellable, I
         return false;
     }
 
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        this.entityTag = this.saveEntityToTag(this.getEntity());
+    }
+
     public void writeSimple(Entity e) {
         CompoundTag tag = new CompoundTag();
         tag.putString("id", EntityType.getKey(e.getType()).toString());


### PR DESCRIPTION
known consequences include something adjacent to void trading and villagers losing trade offer data if they were not jarred at Master level