### PR TITLE
Update StarbuncleCharm.java

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/summon_charms/StarbuncleCharm.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/summon_charms/StarbuncleCharm.java
@@ -44,4 +44,20 @@ public class StarbuncleCharm extends AbstractSummonCharm implements AliasProvide
             new Alias("item_transporter", "Item Transporter")
         );
     }
+
+    @Override
+    public void appendHoverText(@NotNull ItemStack stack, @NotNull TooltipContext context, @NotNull List<Component> tooltip2, @NotNull TooltipFlag flagIn) {
+        StarbuncleCharmData data = stack.get(DataComponentRegistry.STARBUNCLE_DATA);
+        if(data != null) {
+            data.getName().ifPresent(tooltip2::add);
+            if(data.getAdopter() != null && !data.getAdopter().isEmpty()) {
+                tooltip2.add(Component.translatable("ars_nouveau.adopter", data.getAdopter()).withStyle(Style.EMPTY.withColor(ChatFormatting.GOLD)));
+            }
+            if(data.getBio() != null && !data.getBio().isEmpty()) {
+                tooltip2.add(Component.literal(data.getBio()).withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_PURPLE)));
+            }
+        } else {
+            super.appendHoverText(stack, context, tooltip2, flagIn);
+        }
+    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/summon_charms/StarbuncleCharm.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/summon_charms/StarbuncleCharm.java
@@ -7,9 +7,13 @@ import com.hollingsworth.arsnouveau.common.entity.Starbuncle;
 import com.hollingsworth.arsnouveau.common.items.data.StarbuncleCharmData;
 import com.hollingsworth.arsnouveau.setup.registry.DataComponentRegistry;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.List;
@@ -45,19 +49,14 @@ public class StarbuncleCharm extends AbstractSummonCharm implements AliasProvide
         );
     }
 
+
+
     @Override
     public void appendHoverText(@NotNull ItemStack stack, @NotNull TooltipContext context, @NotNull List<Component> tooltip2, @NotNull TooltipFlag flagIn) {
+        super.appendHoverText(stack, context, tooltip2, flagIn);
         StarbuncleCharmData data = stack.get(DataComponentRegistry.STARBUNCLE_DATA);
         if(data != null) {
-            data.getName().ifPresent(tooltip2::add);
-            if(data.getAdopter() != null && !data.getAdopter().isEmpty()) {
-                tooltip2.add(Component.translatable("ars_nouveau.adopter", data.getAdopter()).withStyle(Style.EMPTY.withColor(ChatFormatting.GOLD)));
-            }
-            if(data.getBio() != null && !data.getBio().isEmpty()) {
-                tooltip2.add(Component.literal(data.getBio()).withStyle(Style.EMPTY.withColor(ChatFormatting.DARK_PURPLE)));
-            }
-        } else {
-            super.appendHoverText(stack, context, tooltip2, flagIn);
+            data.addToTooltip(context, tooltip2::add, flagIn);
         }
     }
 }


### PR DESCRIPTION
Quick stab at fixing the missing hover text for Starbuncle Charms to display adopter info. Quickly done in the github UI without any testing, so this might be horribly broken and non-working