### PR TITLE
Fix Starby extraction logic

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/carbuncle/StarbyTransportBehavior.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/carbuncle/StarbyTransportBehavior.java
@@ -169,7 +169,7 @@ public class StarbyTransportBehavior extends StarbyListBehavior {
 
         if (iItemHandler == null) return false;
         for (int j = 0; j < iItemHandler.getSlots(); j++) {
-            ItemStack stack = iItemHandler.getStackInSlot(j);
+            ItemStack stack = iItemHandler.extractItem(j, 1, true);
             if (!stack.isEmpty() && getValidStorePos(stack) != null) {
                 return true;
             }


### PR DESCRIPTION
Fixes an issue where, if an item handler didn't allow extracting a stack, a Starbuncle would get stuck sitting next to that container and trying fruitlessly to extract it.