### PR TITLE
[1.20] fix: EntityMixin crash

### DIFF
--- a/src/generated/resources/.cache/73a0c150702b0db33c4f7a4031c7885e3223a862
+++ b/src/generated/resources/.cache/73a0c150702b0db33c4f7a4031c7885e3223a862
@@ -1,4 +1,4 @@
-// 1.20.1	2024-04-28T11:08:37.1245583	Tags for minecraft:mob_effect mod id ars_nouveau
+// 1.20.1	2025-04-05T21:17:27.9732484	Tags for minecraft:mob_effect mod id ars_nouveau
 08d652bf70406a53ea8f4c794d20f054284765b9 data/ars_nouveau/tags/mob_effect/deny_dispel.json
-eeb33e305587ee0fddec8dfc8d9477b45bc45d7b data/ars_nouveau/tags/mob_effect/to_sync.json
+84bb5fad029e44f32f49e09611492a3f0cede482 data/ars_nouveau/tags/mob_effect/to_sync.json
 0315b9264874191953c091e06cf2d340f81d6d67 data/ars_nouveau/tags/mob_effect/unstable_gifts.json

--- a/src/generated/resources/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
+++ b/src/generated/resources/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
@@ -1,2 +1,2 @@
-// 1.20.1	2024-11-11T12:12:30.5120229	Languages: en_us
-af67fa9def1dcb020997365fe232f67dcf0e1a70 assets/ars_nouveau/lang/en_us.json
+// 1.20.1	2025-04-05T21:17:27.9838002	Languages: en_us
+d49c458d3bef92264a193505d0d10284ba1effbc assets/ars_nouveau/lang/en_us.json

--- a/src/generated/resources/data/ars_nouveau/tags/mob_effect/to_sync.json
+++ b/src/generated/resources/data/ars_nouveau/tags/mob_effect/to_sync.json
@@ -1,5 +1,5 @@
 {
   "values": [
-    "ars_nouveau:soggy"
+    "ars_nouveau:soaked"
   ]
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/mixin/EntityMixin.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/mixin/EntityMixin.java
@@ -6,6 +6,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Entity.class)
 public class EntityMixin {
@@ -18,12 +20,12 @@ public class EntityMixin {
         return original;
     }
 
-    @ModifyReturnValue(method = "setSecondsOnFire", at = @At("RETURN"))
-    private int ars_nouveau$setSecondsOnFire(int original) {
-        if (((Entity) (Object) this) instanceof LivingEntity livingEntity && livingEntity.hasEffect(ModPotions.SOAKED_EFFECT.get())) {
-            return 0;
+    @Inject(method = "setRemainingFireTicks", at = @At("HEAD"), cancellable = true)
+    private void ars_nouveau$setSecondsOnFire(int pRemainingFireTicks, CallbackInfo ci) {
+        if (((Entity) (Object) this) instanceof LivingEntity livingEntity && livingEntity.hasEffect(ModPotions.SOAKED_EFFECT.get()) && pRemainingFireTicks > 0) {
+            livingEntity.clearFire();
+            ci.cancel();
         }
-        return original;
     }
 
 }


### PR DESCRIPTION
The 1.20 version of EntityMixin's `ars_nouveau$setSecondsOnFire` method was crashing on startup due to trying to modify the return value of `Entity.setSecondOnFire` (which is a void), so I just backported the 1.21 equivalent for it. Also reran the datagen, because it had been referencing the nonexistent `ars_nouveau:soggy` in the to_sync mob effect tag instead of `ars_nouveau:soaked`.