### PR TITLE
Command to enable/disable debug numbers

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/ArsNouveauAPI.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/ArsNouveauAPI.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
-import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.common.brewing.BrewingRecipe;
 
@@ -33,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ArsNouveauAPI {
 
     //This is intended as a dev debug tool, used in mana bars. Do not make into a config option with a PR. A Starkiller will be dispatched if you do.
-    public static boolean ENABLE_DEBUG_NUMBERS = !FMLEnvironment.production;
+    public static boolean ENABLE_DEBUG_NUMBERS;
 
     private ConcurrentHashMap<ResourceLocation, IScryer> scryerMap = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/command/DebugNumberCommand.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/command/DebugNumberCommand.java
@@ -1,0 +1,33 @@
+package com.hollingsworth.arsnouveau.common.command;
+
+import com.hollingsworth.arsnouveau.common.network.Networking;
+import com.hollingsworth.arsnouveau.common.network.PacketToggleDebug;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.server.level.ServerPlayer;
+
+public class DebugNumberCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("ars-debug").
+                requires(sender -> sender.hasPermission(1))
+                .then(Commands.literal("on").executes(context -> toggleDebugNumbers(context.getSource(), true)))
+                .then(Commands.literal("off").executes(context -> toggleDebugNumbers(context.getSource(), false))));
+    }
+
+    private static int toggleDebugNumbers(CommandSourceStack source, boolean enable) {
+        ServerPlayer player;
+        try {
+            player = source.getPlayerOrException();
+        } catch (CommandSyntaxException e) {
+            e.printStackTrace();
+            return 0;
+        }
+        Networking.sendToPlayerClient(new PacketToggleDebug(enable), player);
+        return 1;
+    }
+
+
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
@@ -55,7 +55,6 @@ import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.monster.Witch;
 import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.food.FoodData;
@@ -94,11 +93,13 @@ public class EventHandler {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void resourceLoadEvent(AddReloadListenerEvent event) {
         event.addListener(new SimplePreparableReloadListener<>() {
+            @SuppressWarnings({"NullableProblems", "DataFlowIssue"})
             @Override
             protected Object prepare(ResourceManager pResourceManager, ProfilerFiller pProfiler) {
                 return null;
             }
 
+            @SuppressWarnings("NullableProblems")
             @Override
             protected void apply(Object pObject, ResourceManager pResourceManager, ProfilerFiller pProfiler) {
                 MultiRecipeWrapper.RECIPE_CACHE = new HashMap<>();
@@ -337,6 +338,7 @@ public class EventHandler {
         LearnGlyphCommand.register(event.getDispatcher());
         AdoptCommand.register(event.getDispatcher());
         DroplessMobsCommand.register(event.getDispatcher());
+        DebugNumberCommand.register(event.getDispatcher());
         if(!FMLEnvironment.production){
             ExportDocsCommand.register(event.getDispatcher());
         }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/network/Networking.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/network/Networking.java
@@ -77,7 +77,7 @@ public class Networking {
         reg.playToClient(PacketUpdateGlowColor.TYPE, PacketUpdateGlowColor.CODEC, Networking::handle);
         reg.playToServer(PacketUpdateDominionWand.TYPE, PacketUpdateDominionWand.CODEC, Networking::handle);
         reg.playToServer(PacketCastSpell.TYPE, PacketCastSpell.CODEC, Networking::handle);
-
+        reg.playToClient(PacketToggleDebug.TYPE, PacketToggleDebug.CODEC, Networking::handle);
     }
 
     public static <T extends AbstractPacket> void handle(T message, IPayloadContext ctx) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/network/PacketToggleDebug.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/network/PacketToggleDebug.java
@@ -1,7 +1,7 @@
 package com.hollingsworth.arsnouveau.common.network;
 
 import com.hollingsworth.arsnouveau.ArsNouveau;
-import com.hollingsworth.arsnouveau.common.light.LightManager;
+import com.hollingsworth.arsnouveau.api.ArsNouveauAPI;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -9,11 +9,12 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
 
-public class PacketToggleLight extends AbstractPacket {
+public class PacketToggleDebug extends AbstractPacket {
+
     boolean enabled;
 
     //Decoder
-    public PacketToggleLight(RegistryFriendlyByteBuf buf) {
+    public PacketToggleDebug(RegistryFriendlyByteBuf buf) {
         enabled = buf.readBoolean();
     }
 
@@ -22,21 +23,23 @@ public class PacketToggleLight extends AbstractPacket {
         buf.writeBoolean(enabled);
     }
 
-    public PacketToggleLight(boolean stack) {
+    public PacketToggleDebug(boolean stack) {
         this.enabled = stack;
     }
 
     @Override
     public void onClientReceived(Minecraft minecraft, Player player) {
-        LightManager.toggleLightsAndConfig(enabled);
+        ArsNouveauAPI.ENABLE_DEBUG_NUMBERS = enabled;
     }
 
-    public static final Type<PacketToggleLight> TYPE = new Type<>(ArsNouveau.prefix("toggle_light"));
-    public static final StreamCodec<RegistryFriendlyByteBuf, PacketToggleLight> CODEC = StreamCodec.ofMember(PacketToggleLight::toBytes, PacketToggleLight::new);
+    public static final Type<PacketToggleDebug> TYPE = new Type<>(ArsNouveau.prefix("toggle_debug"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, PacketToggleDebug> CODEC = StreamCodec.ofMember(PacketToggleDebug::toBytes, PacketToggleDebug::new);
 
 
     @Override
     public @NotNull Type<? extends CustomPacketPayload> type() {
         return TYPE;
     }
+
+
 }


### PR DESCRIPTION
Disables by default the numbers on the mana bar even in dev and adds a command to switch them on/off if needed. Needs op permission.