### PR TITLE
Change override with inject return

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/mixin/EntityMixin.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/mixin/EntityMixin.java
@@ -1,7 +1,10 @@
 package com.hollingsworth.arsnouveau.common.mixin;
 
 import com.hollingsworth.arsnouveau.api.event.EntityPreRemovalEvent;
+import com.hollingsworth.arsnouveau.client.ClientInfo;
+import com.hollingsworth.arsnouveau.client.gui.Color;
 import com.hollingsworth.arsnouveau.common.entity.BubbleEntity;
+import com.hollingsworth.arsnouveau.common.spell.effect.EffectLight;
 import com.hollingsworth.arsnouveau.setup.registry.ModPotions;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.world.entity.Entity;
@@ -13,11 +16,15 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)
-public class EntityMixin {
+public abstract class EntityMixin {
 
     @Shadow public Level level;
+
+    @Shadow
+    public abstract boolean isCurrentlyGlowing();
 
     @ModifyReturnValue(method = "isInWaterOrRain", at = @At("RETURN"))
     private boolean ars_nouveau$isInWaterOrRain(boolean original) {
@@ -42,5 +49,26 @@ public class EntityMixin {
 
     private static boolean isWet(LivingEntity livingEntity){
         return livingEntity.hasEffect(ModPotions.SOAKED_EFFECT) || livingEntity.getVehicle() instanceof BubbleEntity;
+    }
+
+    /**
+     * Used to make the glowing effect on mobs use the tag applied by {@link EffectLight}.
+     */
+    @Inject(method = "getTeamColor", at = @At("RETURN"), cancellable = true)
+    public void ars_nouveau$getTeamColor(CallbackInfoReturnable<Integer> cir) {
+        int color = cir.getReturnValue();
+        if (color == 16777215 && isCurrentlyGlowing()) {
+            if (((Object) this) instanceof LivingEntity livingEntity) {
+                var perData = livingEntity.getPersistentData();
+                if (perData.contains("ars_nouveau:glow_color")) {
+                    color = perData.getInt("ars_nouveau:glow_color");
+                    if (color < 0) {
+                        color = Color.rainbowColor(ClientInfo.ticksInGame).getRGB();
+                    }
+                    cir.setReturnValue(color);
+                }
+            }
+
+        }
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/mixin/perks/PerkLivingEntity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/mixin/perks/PerkLivingEntity.java
@@ -1,11 +1,8 @@
 package com.hollingsworth.arsnouveau.common.mixin.perks;
 
 import com.hollingsworth.arsnouveau.api.util.PerkUtil;
-import com.hollingsworth.arsnouveau.client.ClientInfo;
-import com.hollingsworth.arsnouveau.client.gui.Color;
 import com.hollingsworth.arsnouveau.common.perk.DepthsPerk;
 import com.hollingsworth.arsnouveau.common.perk.JumpHeightPerk;
-import com.hollingsworth.arsnouveau.common.spell.effect.EffectLight;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -40,24 +37,5 @@ public abstract class PerkLivingEntity extends Entity {
     public PerkLivingEntity(EntityType<?> pEntityType, Level pLevel) {
         super(pEntityType, pLevel);
     }
-
-    /**
-     * Used to make the glowing effect on mobs use the tag applied by {@link EffectLight}.
-     */
-    @Override
-    public int getTeamColor() {
-        int color = super.getTeamColor();
-        if (color == 16777215 && this.isCurrentlyGlowing()) {
-            var perData = this.getPersistentData();
-            if (perData.contains("GlowColor")) {
-                color = perData.getInt("GlowColor");
-                if (color < 0) {
-                    color = Color.rainbowColor(ClientInfo.ticksInGame).getRGB();
-                }
-            }
-        }
-        return color;
-    }
-
 
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/network/PacketUpdateGlowColor.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/network/PacketUpdateGlowColor.java
@@ -33,9 +33,9 @@ public class PacketUpdateGlowColor extends AbstractPacket {
     public void onClientReceived(Minecraft mc, Player player) {
         if (player.level.getEntity(this.entity) instanceof LivingEntity living)
             if (color != 0) {
-                living.getPersistentData().putInt("GlowColor", color);
+                living.getPersistentData().putInt("ars_nouveau:glow_color", color);
             } else {
-                living.getPersistentData().remove("GlowColor");
+                living.getPersistentData().remove("ars_nouveau:glow_color");
             }
     }
 


### PR DESCRIPTION
Simply changes the override of getTeamColor to be a more compatible inject. Also prefixes key used for the persistent data

DevNote: Consider switching the persistent data storage to data attachments. Requires particle color to be compatible with its serialization