### PR TITLE
fix: show storage tooltips

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/events/ClientEvents.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/events/ClientEvents.java
@@ -3,6 +3,7 @@ package com.hollingsworth.arsnouveau.client.events;
 import com.hollingsworth.arsnouveau.ArsNouveau;
 import com.hollingsworth.arsnouveau.api.registry.DynamicTooltipRegistry;
 import com.hollingsworth.arsnouveau.api.registry.GenericRecipeRegistry;
+import com.hollingsworth.arsnouveau.client.ClientInfo;
 import com.hollingsworth.arsnouveau.client.gui.DocItemTooltipHandler;
 import com.hollingsworth.arsnouveau.client.gui.SchoolTooltip;
 import com.hollingsworth.arsnouveau.client.gui.SpellTooltip;
@@ -124,6 +125,9 @@ public class ClientEvents {
     public static void onTooltip(final ItemTooltipEvent event) {
         ItemStack stack = event.getItemStack();
         DynamicTooltipRegistry.appendTooltips(stack, event.getContext(), event.getToolTip()::add, event.getFlags());
+        for (var tooltip: ClientInfo.storageTooltip) {
+            event.getToolTip().add(tooltip);
+        }
     }
 
     public static Component localize(String key, Object... params) {


### PR DESCRIPTION
previously set but never accessed