### PR TITLE
fix: prevent breeze feedback loop

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/mob_jar/BreezeBehavior.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/mob_jar/BreezeBehavior.java
@@ -3,6 +3,7 @@ package com.hollingsworth.arsnouveau.common.mob_jar;
 import com.hollingsworth.arsnouveau.api.mob_jar.JarBehavior;
 import com.hollingsworth.arsnouveau.common.block.MobJar;
 import com.hollingsworth.arsnouveau.common.block.tile.MobJarTile;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.monster.breeze.Breeze;
@@ -12,7 +13,7 @@ import net.minecraft.world.phys.Vec3;
 public class BreezeBehavior extends JarBehavior<Breeze> {
     @Override
     public void onRedstonePower(MobJarTile tile) {
-        if (!(tile.getLevel() instanceof ServerLevel level)) {
+        if (!(tile.getLevel() instanceof ServerLevel level) || tile.getExtraDataTag().getLong("lastActive") == level.getGameTime()) {
             return;
         }
 
@@ -24,5 +25,9 @@ public class BreezeBehavior extends JarBehavior<Breeze> {
         breeze.playSound(SoundEvents.BREEZE_SHOOT, 1.5F, 1.0F);
         windCharge.shoot(dir.x, dir.y, dir.z, 0.7F, (float) (5 - level.getDifficulty().getId() * 4));
         level.addFreshEntity(windCharge);
+
+        var tag = new CompoundTag();
+        tag.putLong("lastActive", level.getGameTime());
+        tile.setExtraDataTag(tag);
     }
 }


### PR DESCRIPTION
if a lever activation causes at least 3 breeze wind charges to flip it, the number of wind charges created will grow exponentially