### PR TITLE
Fix duration used instead of amplification

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGravity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectGravity.java
@@ -46,7 +46,7 @@ public class EffectGravity extends AbstractEffect implements IPotionEffect {
                 this.applyConfigPotion(living, ModPotions.GRAVITY_EFFECT, spellStats);
             } else {
                 Entity entity = rayTraceResult.getEntity();
-                entity.setDeltaMovement(entity.getDeltaMovement().add(0, -1.0 - spellStats.getDurationMultiplier(), 0));
+                entity.setDeltaMovement(entity.getDeltaMovement().add(0, -1.0 - spellStats.getAmpMultiplier(), 0));
                 entity.hurtMarked = true;
             }
         }


### PR DESCRIPTION
Docs seem to imply it was not an intended feature to scale the gravity on the duration stat