### PR TITLE
fix: armor upgrade logic

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/ArmorUpgradeRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/ArmorUpgradeRecipe.java
@@ -20,6 +20,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ArmorUpgradeRecipe extends EnchantingApparatusRecipe implements ITextOutput{
@@ -51,14 +52,6 @@ public class ArmorUpgradeRecipe extends EnchantingApparatusRecipe implements ITe
             return false;
         }
         return armorPerkHolder.getTier() == (tier - 1);
-    }
-
-    @Override
-    public boolean matches(ApparatusRecipeInput input, Level level, @org.jetbrains.annotations.Nullable Player player) {
-        if(this.pedestalItems().size() != input.pedestals().size()){
-            return false;
-        }
-        return this.doesReagentMatch(input, level, player);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/EnchantingApparatusRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/EnchantingApparatusRecipe.java
@@ -49,10 +49,8 @@ public class EnchantingApparatusRecipe implements IEnchantingRecipe {
 
     @Override
     public boolean matches(ApparatusRecipeInput input, Level level, @Nullable Player player) {
-        if(this.pedestalItems.size() != input.pedestals().size()){
-            return false;
-        }
-        return doesReagentMatch(input, level, player) && doPedestalsMatch(input);
+        // Check pedestal match first as it is less costly than enchantment checks
+        return doPedestalsMatch(input) && doesReagentMatch(input, level, player);
     }
 
     public boolean doPedestalsMatch(ApparatusRecipeInput input){

--- a/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/EnchantmentRecipe.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/crafting/recipes/EnchantmentRecipe.java
@@ -53,12 +53,6 @@ public class EnchantmentRecipe extends EnchantingApparatusRecipe {
         return true;
     }
 
-    @Override
-    public boolean matches(ApparatusRecipeInput input, Level level, @org.jetbrains.annotations.Nullable Player player) {
-        // Check pedestal match first as it is less costly than enchantment checks
-        return doPedestalsMatch(input) && doesReagentMatch(input, level, player);
-    }
-
     public Holder<Enchantment> holderFor(Level level){
         return level.registryAccess().registryOrThrow(Registries.ENCHANTMENT).getHolderOrThrow(enchantmentKey);
     }


### PR DESCRIPTION
`matches` only cares about number of reagents, not what they actually are.