### PR TITLE
fix: remove client methods in tooltips

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/documentation/BaseDocScreen.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/documentation/BaseDocScreen.java
@@ -136,8 +136,7 @@ public class BaseDocScreen extends BaseScreen {
 
             BookmarkButton slot = addRenderableWidget(new BookmarkButton(screenLeft + 281, screenTop + 1 + 15 * (i + 1), entry, (b) ->{
                 if(entry == null) return;
-                boolean isShiftDown = InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), Minecraft.getInstance().options.keyShift.getKey().getValue());
-                if(isShiftDown){
+                if(isShiftDown()){
                     bookmarks.remove(entryId);
                     initBookmarks();
                 }else {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/Glyph.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/Glyph.java
@@ -8,7 +8,6 @@ import com.hollingsworth.arsnouveau.client.gui.SchoolTooltip;
 import com.hollingsworth.arsnouveau.common.capability.IPlayerCap;
 import com.hollingsworth.arsnouveau.setup.config.Config;
 import com.hollingsworth.arsnouveau.setup.registry.CapabilityRegistry;
-import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
@@ -91,10 +90,10 @@ public class Glyph extends ModItem {
                 tooltip2.add(Component.translatable("tooltip.ars_nouveau.glyph_unknown").setStyle(Style.EMPTY.withColor(ChatFormatting.DARK_RED)));
             }
         }
-        if (InputConstants.isKeyDown(ArsNouveau.proxy.getMinecraft().getWindow().getWindow(),ArsNouveau.proxy.getMinecraft().options.keyShift.getKey().getValue())) {
+        if (flagIn.hasShiftDown()) {
             tooltip2.add(spellPart.getBookDescLang());
         } else {
-            tooltip2.add(Component.translatable("tooltip.ars_nouveau.hold_shift", ArsNouveau.proxy.getMinecraft().options.keyShift.getKey().getDisplayName()));
+            tooltip2.add(Component.translatable("tooltip.ars_nouveau.hold_shift", Component.keybind("key.sneak")));
         }
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/PerkItem.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/PerkItem.java
@@ -2,8 +2,6 @@ package com.hollingsworth.arsnouveau.common.items;
 
 import com.hollingsworth.arsnouveau.api.perk.IPerk;
 import com.hollingsworth.arsnouveau.setup.registry.ItemsRegistry;
-import com.mojang.blaze3d.platform.InputConstants;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -34,10 +32,10 @@ public class PerkItem extends ModItem {
         if (perk == null)
             return;
 
-        if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), Minecraft.getInstance().options.keyShift.getKey().getValue())) {
+        if (flagIn.hasShiftDown()) {
             tooltip2.add(Component.translatable(perk.getDescriptionKey()));
         } else {
-            tooltip2.add(Component.translatable("tooltip.ars_nouveau.hold_shift", Minecraft.getInstance().options.keyShift.getKey().getDisplayName()));
+            tooltip2.add(Component.translatable("tooltip.ars_nouveau.hold_shift", Component.keybind("key.sneak")));
         }
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/RitualTablet.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/RitualTablet.java
@@ -3,9 +3,7 @@ package com.hollingsworth.arsnouveau.common.items;
 import com.hollingsworth.arsnouveau.api.ritual.AbstractRitual;
 import com.hollingsworth.arsnouveau.common.block.tile.RitualBrazierTile;
 import com.hollingsworth.arsnouveau.setup.registry.ItemsRegistry;
-import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.world.InteractionResult;
@@ -49,10 +47,10 @@ public class RitualTablet extends ModItem {
     public void appendHoverText(@NotNull ItemStack stack, @NotNull TooltipContext context, @NotNull List<Component> tooltip2, @NotNull TooltipFlag flagIn) {
         super.appendHoverText(stack, context, tooltip2, flagIn);
         tooltip2.add(Component.translatable("tooltip.ars_nouveau.tablet"));
-        if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), Minecraft.getInstance().options.keyShift.getKey().getValue())) {
+        if (flagIn.hasShiftDown()) {
             tooltip2.add(Component.translatable(ritual.getDescriptionKey()));
         } else {
-            tooltip2.add(Component.translatable("tooltip.ars_nouveau.hold_shift", Minecraft.getInstance().options.keyShift.getKey().getDisplayName()).withStyle(Style.EMPTY.withColor(ChatFormatting.BLUE)));
+            tooltip2.add(Component.translatable("tooltip.ars_nouveau.hold_shift", Component.keybind("key.sneak")).withStyle(Style.EMPTY.withColor(ChatFormatting.BLUE)));
         }
     }
 


### PR DESCRIPTION
Sometimes tooltips can be computed off the render thread, so it's not safe to use input constants.