### PR TITLE
fix: sync mana capability on login

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/event/ManaCapEvents.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/event/ManaCapEvents.java
@@ -70,7 +70,7 @@ public class ManaCapEvents {
 //    }
 
     @SubscribeEvent
-    public static void playerLoggedIn(PlayerEvent.StartTracking e) {
+    public static void playerLoggedIn(PlayerEvent.PlayerLoggedInEvent e) {
         syncPlayerEvent(e.getEntity());
     }
 


### PR DESCRIPTION
was previously syncing on StartTracking, which is `Fired when an Entity is started to be "tracked" by this player (the player receives updates about this entity, e.g. motion).`