### PR TITLE
Move UnbreakablePerk to mixin 

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/mixin/perks/UnbreakablePerk.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/mixin/perks/UnbreakablePerk.java
@@ -1,0 +1,21 @@
+package com.hollingsworth.arsnouveau.common.mixin.perks;
+
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static com.hollingsworth.arsnouveau.setup.registry.DataComponentRegistry.UNBREAKING;
+
+@Mixin(ItemStack.class)
+public abstract class UnbreakablePerk implements DataComponentHolder {
+
+    @Inject(method = "isDamageableItem", at = @At("HEAD"), cancellable = true)
+    void ars_nouveau$unbreakablePerk(CallbackInfoReturnable<Boolean> cir) {
+        if (this.getOrDefault(UNBREAKING, false))
+            cir.setReturnValue(false);
+    }
+
+}

--- a/src/main/resources/ars_nouveau.mixins.json
+++ b/src/main/resources/ars_nouveau.mixins.json
@@ -39,6 +39,7 @@
     "looting.EnchantedCountIncreaseFunctionMixin",
     "looting.LootItemRandomChanceWithEnchantedBonusConditionMixin",
     "perks.PerkLivingEntity",
+    "perks.UnbreakablePerk",
     "redstone.RedstoneLevelMixin",
     "rewind.RewindEntityMixin",
     "structure.StructureProcessorAccessor",


### PR DESCRIPTION
Current implementation of unbreakability was ignored by most sources of damage, this mixin chains in the check with the vanilla UNBREAKABLE data component 