### PR TITLE
Underfoot Entity targeting

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodUnderfoot.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/method/MethodUnderfoot.java
@@ -10,9 +10,11 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
 
 public class MethodUnderfoot extends AbstractCastMethod {
@@ -24,7 +26,17 @@ public class MethodUnderfoot extends AbstractCastMethod {
 
     @Override
     public CastResolveType onCast(@Nullable ItemStack stack, LivingEntity caster, Level world, SpellStats spellStats, SpellContext context, SpellResolver resolver) {
-        resolver.onResolveEffect(caster.getCommandSenderWorld(), new BlockHitResult(caster.position, Direction.DOWN, caster.blockPosition().below(), true));
+        // check if the caster has an entity beneath them or is riding one
+        if (caster.getVehicle() != null) {
+            resolver.onResolveEffect(caster.getCommandSenderWorld(), new EntityHitResult(caster.getVehicle()));
+        } else {
+            List<Entity> nearbyEntities = world.getEntities(caster, caster.getBoundingBox().inflate(0.1, 1.5, 0.1));
+            if (!nearbyEntities.isEmpty()) {
+                resolver.onResolveEffect(caster.getCommandSenderWorld(), new EntityHitResult(nearbyEntities.getFirst()));
+            } else {
+                resolver.onResolveEffect(caster.getCommandSenderWorld(), new BlockHitResult(caster.position, Direction.DOWN, caster.blockPosition().below(), true));
+            }
+        }
         return CastResolveType.SUCCESS;
     }
 
@@ -43,7 +55,17 @@ public class MethodUnderfoot extends AbstractCastMethod {
 
     @Override
     public CastResolveType onCastOnEntity(@Nullable ItemStack stack, LivingEntity caster, Entity target, InteractionHand hand, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
-        resolver.onResolveEffect(caster.getCommandSenderWorld(), new BlockHitResult(caster.position, Direction.DOWN, caster.blockPosition().below(), true));
+        // check if the caster has an entity beneath them or is riding one
+        if (caster.getVehicle() != null) {
+            resolver.onResolveEffect(caster.getCommandSenderWorld(), new EntityHitResult(caster.getVehicle()));
+        } else {
+            List<Entity> nearbyEntities = caster.level().getEntities(caster, caster.getBoundingBox().inflate(0.1, 1.5, 0.1));
+            if (!nearbyEntities.isEmpty()) {
+                resolver.onResolveEffect(caster.getCommandSenderWorld(), new EntityHitResult(nearbyEntities.getFirst()));
+            } else {
+                resolver.onResolveEffect(caster.getCommandSenderWorld(), new BlockHitResult(caster.position, Direction.DOWN, caster.blockPosition().below(), true));
+            }
+        }
         return CastResolveType.SUCCESS;
     }
 


### PR DESCRIPTION
Adds a check for Underfoot to resolve on entities before fallback to block.
Priority order:
- If caster is a passenger, targets its veichle
- Otherwise, checks below the caster if there is an entity (hitbox to tune a bit) to use as target
- Default behavior on blocks if above fails