### PR TITLE
Make cheesing Mining Fatigue harder

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SpellUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SpellUtil.java
@@ -45,20 +45,18 @@ public class SpellUtil {
     }
 
     public static boolean isCorrectHarvestLevel(int strength, BlockState state) {
-        Tier tier = switch (strength) {
-            case 2:
-                yield Tiers.STONE;
-            case 3:
-                yield Tiers.IRON;
-            case 4:
-                yield Tiers.DIAMOND;
-            case 5:
-                yield Tiers.NETHERITE;
-            default:
-                yield Tiers.WOOD;
+        // Zero or negative harvest levels can occur when a caster if afflicted with Mining Fatigue. Breaking blocks
+        // should not be possible in that case to prevent players trivially cheesing Ocean Monuments
+        if (strength <= 0) {
+            return false;
+        }
+        final Tier tier = switch (strength) {
+            case 1 -> Tiers.WOOD;
+            case 2 -> Tiers.STONE;
+            case 3 -> Tiers.IRON;
+            case 4 -> Tiers.DIAMOND;
+            default -> Tiers.NETHERITE;
         };
-        if (strength > 5)
-            tier = Tiers.NETHERITE;
         return !BuiltInRegistries.BLOCK.getOrCreateTag(tier.getIncorrectBlocksForDrops()).contains(state.getBlockHolder());
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBreak.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectBreak.java
@@ -53,9 +53,23 @@ public class EffectBreak extends AbstractEffect {
         BlockPos pos = rayTraceResult.getBlockPos();
         BlockState state;
 
+        /* Balancing for mining fatigue:
+         * Mining fatigue reduces mining speed to ⅓ per level. Since Ars does not represent mining speed in any way,
+         * this is mapped to mana cost by requiring a large amount of amplify glyphs.
+         * Since extremely few blocks require anything but wooden tools (for pickaxes this list is limited to a handful
+         * of ores, and most importantly does not include the Prismarine blocks of ocean monuments for which the mining
+         * fatigue effect was introduced in the first place) this is implemented by reducing the spell amp multiplier
+         * by _3_ (= removing the inherent iron tools level) plus two additional for every level of mining fatigue.
+         *
+         * Thus, to get back to a tool level of 1 (= wooden tools) when afflicted with Mining Fatigue III requires
+         * 7 amplify glyphs; making repeated casting infeasible for anything but the best equipped of spell casters.
+         */
         MobEffectInstance miningFatigue = shooter.getEffect(MobEffects.DIG_SLOWDOWN);
-        if (miningFatigue != null)
-            spellStats.setAmpMultiplier(spellStats.getAmpMultiplier() - miningFatigue.getAmplifier());
+        if (miningFatigue != null) {
+             // MobEffect amplifiers are additive and not absolute, i.e. Mining Fatigue III has an `amplifier` value of 2 and not 3.
+            final int miningFatigueAmplifier = 3 + ((miningFatigue.getAmplifier() + 1) * 2);
+            spellStats.setAmpMultiplier(spellStats.getAmpMultiplier() - miningFatigueAmplifier);
+        }
 
         double aoeBuff = spellStats.getAoeMultiplier();
         int pierceBuff = spellStats.getBuffCount(AugmentPierce.INSTANCE);


### PR DESCRIPTION
Currently mining fatigue is effectively bypassed entirely by the break spell. While in theory Mining Fatigue reduces the harvest level of the spell any value below 2 (including negative ones) are still treated as wooden tools, which can still harvest almost all blocks in the game. Notably this includes Prismarine and so entirely sidesteps the reason why mining fatigue was added to the game in the first place.
This PR does two changes: 
1. It makes it so that harvest levels of zero and below (which only really occur with Mining Fatigue) can't break any blocks
2. It makes mining fatigue much more expensive on the amplify glyph cost, since otherwise a single amplify would again completely sidestep the effect.