### PR TITLE
fix: prevent familiars from targeting owner

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/familiar/FamOwnerHurtByTargetGoal.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/familiar/FamOwnerHurtByTargetGoal.java
@@ -6,6 +6,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import org.jetbrains.annotations.Nullable;
 
 public class FamOwnerHurtByTargetGoal extends TargetGoal {
 
@@ -30,6 +31,14 @@ public class FamOwnerHurtByTargetGoal extends TargetGoal {
             int i = livingentity.getLastHurtByMobTimestamp();
             return i != this.timestamp && this.canAttack(this.ownerLastHurtBy, TargetingConditions.DEFAULT) && this.familiar.wantsToAttack(this.ownerLastHurtBy, livingentity);
         }
+    }
+
+    @Override
+    protected boolean canAttack(@Nullable LivingEntity potentialTarget, TargetingConditions targetPredicate) {
+        if (potentialTarget == null) {
+            return false;
+        }
+        return !potentialTarget.getUUID().equals(familiar.getOwnerID()) && super.canAttack(potentialTarget, targetPredicate);
     }
 
     public void start() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/familiar/FamOwnerHurtTargetGoal.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/familiar/FamOwnerHurtTargetGoal.java
@@ -7,6 +7,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumSet;
 
@@ -32,6 +33,14 @@ public class FamOwnerHurtTargetGoal extends TargetGoal {
             int i = livingentity.getLastHurtMobTimestamp();
             return i != this.timestamp && this.canAttack(this.ownerLastHurt, TargetingConditions.DEFAULT) && this.familiar.wantsToAttack(this.ownerLastHurt, livingentity);
         }
+    }
+
+    @Override
+    protected boolean canAttack(@Nullable LivingEntity potentialTarget, TargetingConditions targetPredicate) {
+        if (potentialTarget == null) {
+            return false;
+        }
+        return !potentialTarget.getUUID().equals(familiar.getOwnerID()) && super.canAttack(potentialTarget, targetPredicate);
     }
 
     @Override


### PR DESCRIPTION
current behaviour causes wixie familiars to debuff their owners if they somehow manage to hurt themselves