### PR TITLE
[Issue] - Music Disc Song Length Value Correction.

### DIFF
--- a/src/generated/resources/data/ars_nouveau/jukebox_song/aria_biblio.json
+++ b/src/generated/resources/data/ars_nouveau/jukebox_song/aria_biblio.json
@@ -3,6 +3,6 @@
   "description": {
     "translate": "jukebox_song.ars_nouveau.aria_biblio"
   },
-  "length_in_seconds": 4800.0,
+  "length_in_seconds": 240.0,
   "sound_event": "ars_nouveau:aria_biblio"
 }

--- a/src/generated/resources/data/ars_nouveau/jukebox_song/firel_the_wild_hunt.json
+++ b/src/generated/resources/data/ars_nouveau/jukebox_song/firel_the_wild_hunt.json
@@ -3,6 +3,6 @@
   "description": {
     "translate": "jukebox_song.ars_nouveau.firel_the_wild_hunt"
   },
-  "length_in_seconds": 2420.0,
+  "length_in_seconds": 121.0,
   "sound_event": "ars_nouveau:firel_the_wild_hunt"
 }

--- a/src/generated/resources/data/ars_nouveau/jukebox_song/thistle_the_sound_of_glass.json
+++ b/src/generated/resources/data/ars_nouveau/jukebox_song/thistle_the_sound_of_glass.json
@@ -3,6 +3,6 @@
   "description": {
     "translate": "jukebox_song.ars_nouveau.thistle_the_sound_of_glass"
   },
-  "length_in_seconds": 3640.0,
+  "length_in_seconds": 182.0,
   "sound_event": "ars_nouveau:thistle_the_sound_of_glass"
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/MusicProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/MusicProvider.java
@@ -26,9 +26,9 @@ public class MusicProvider extends DatapackBuiltinEntriesProvider {
 
 
     public static void bootstrap(BootstrapContext<JukeboxSong> ctx) {
-        register(ctx, JukeboxRegistry.ARIA_BIBLIO, SoundRegistry.ARIA_BIBLIO, 20 * 240, 1);
-        register(ctx, JukeboxRegistry.WILD_HUNT, SoundRegistry.WILD_HUNT, 20 * 121, 2);
-        register(ctx, JukeboxRegistry.SOUND_OF_GLASS, SoundRegistry.SOUND_OF_GLASS, 20 * 182, 3);
+        register(ctx, JukeboxRegistry.ARIA_BIBLIO, SoundRegistry.ARIA_BIBLIO, 240, 1);
+        register(ctx, JukeboxRegistry.WILD_HUNT, SoundRegistry.WILD_HUNT, 121, 2);
+        register(ctx, JukeboxRegistry.SOUND_OF_GLASS, SoundRegistry.SOUND_OF_GLASS, 182, 3);
     }
 
     public static void register(


### PR DESCRIPTION
Issue - [#1979](https://github.com/baileyholl/Ars-Nouveau/issues/1979)

This pull request makes a small but important change to the way song durations are registered in the `MusicProvider` class. The durations for songs are now specified in seconds rather than in game ticks, simplifying the code and making the intent clearer.

- Changed the `register` calls in the `bootstrap` method of `MusicProvider` to use song durations in seconds instead of multiplying by 20 to convert from seconds to ticks.