### PR TITLE
perf: don't use a linked list for dfs

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/util/SpellUtil.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/util/SpellUtil.java
@@ -165,21 +165,24 @@ public class SpellUtil {
     }
 
     private static Set<BlockPos> DFSBlockstates(Level world, Collection<BlockPos> start, int maxBlocks, Predicate<BlockState> isMatch) {
-        LinkedList<BlockPos> searchQueue = new LinkedList<>(start);
+        Queue<BlockPos> searchQueue = new ArrayDeque<>(start);
         HashSet<BlockPos> searched = new HashSet<>(start);
         HashSet<BlockPos> found = new HashSet<>();
 
         while (!searchQueue.isEmpty() && found.size() < maxBlocks) {
-            BlockPos current = searchQueue.removeFirst();
+            BlockPos current = searchQueue.remove();
             BlockState state = world.getBlockState(current);
             if (isMatch.test(state)) {
                 found.add(current);
-                BlockPos.betweenClosedStream(current.offset(1, 1, 1), current.offset(-1, -1, -1)).forEach(neighborMutable -> {
-                    if (searched.contains(neighborMutable)) return;
+                for (BlockPos neighborMutable : BlockPos.betweenClosed(current.offset(1, 1, 1), current.offset(-1, -1, -1))) {
+                    if (searched.contains(neighborMutable)) {
+                        continue;
+                    }
+
                     BlockPos neighbor = neighborMutable.immutable();
                     searched.add(neighbor);
                     searchQueue.add(neighbor);
-                });
+                }
             }
         }
         return found;


### PR DESCRIPTION
## Description

Makes `SpellUtil#DFSBlockstates` use an `ArrayDeque` instead of a `LinkedList`

## Reason for Change

Linked lists are an inefficient solution for queues, ArrayDeque instead implements it as a circular buffer by tracking the starting index.

## Related Issues

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Refactor (no functional changes expected)

## Manual Testing Performed

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
