### PR TITLE
perf: skip serializing properties with default values

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/BaseProperty.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/BaseProperty.java
@@ -52,6 +52,13 @@ public abstract class BaseProperty<T extends BaseProperty<T>> {
         return true;
     }
 
+    /**
+     * Used for network optimizations (for example avoiding serializing default values)
+     */
+    public boolean shouldSkipSerialization() {
+        return false;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(getId(), propertyHolder);

--- a/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/ColorProperty.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/ColorProperty.java
@@ -270,6 +270,12 @@ public class ColorProperty extends BaseProperty<ColorProperty> {
     }
 
     @Override
+    public boolean shouldSkipSerialization() {
+        // ParticleColor.defaultParticleColor().getColor() == 16718260
+        return this.tintDisabled && this.particleColor.getColor() == 16718260 && this.propertyHolder.size() == 0;
+    }
+
+    @Override
     public IPropertyType<ColorProperty> getType() {
         return ParticlePropertyRegistry.COLOR_PROPERTY.get();
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/ModelProperty.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/ModelProperty.java
@@ -74,6 +74,10 @@ public class ModelProperty extends BaseProperty<ModelProperty> {
         this.subPropMap = subPropMap;
     }
 
+    @Override
+    public boolean shouldSkipSerialization() {
+        return this.selectedResource == NONE && subPropMap.size() == 0;
+    }
 
     @Override
     public ParticleConfigWidgetProvider buildWidgets(int x, int y, int width, int height) {

--- a/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/ParticleTypeProperty.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/ParticleTypeProperty.java
@@ -93,6 +93,11 @@ public class ParticleTypeProperty extends BaseProperty<ParticleTypeProperty> {
     }
 
     @Override
+    public boolean shouldSkipSerialization() {
+        return this.type == ModParticles.NEW_GLOW_TYPE.get() && this.propertyHolder.size() == 0;
+    }
+
+    @Override
     public ParticleConfigWidgetProvider buildWidgets(int x, int y, int width, int height) {
         List<DocEntryButton> buttons = new ArrayList<>();
         var particleEntries = new ArrayList<>(PARTICLE_TYPES.entrySet());

--- a/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/RuneTextureProperty.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/RuneTextureProperty.java
@@ -61,6 +61,10 @@ public class RuneTextureProperty extends BaseProperty<RuneTextureProperty> {
         this.runeTexture = TEXTURES.get(0);
     }
 
+    @Override
+    public boolean shouldSkipSerialization() {
+        return this.propertyHolder.size() == 0 && Objects.equals(this.runeTexture, TEXTURES.get(0));
+    }
 
     @Override
     public ParticleConfigWidgetProvider buildWidgets(int x, int y, int width, int height) {

--- a/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/SoundProperty.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/SoundProperty.java
@@ -53,6 +53,11 @@ public class SoundProperty extends BaseProperty<SoundProperty> {
     }
 
     @Override
+    public boolean shouldSkipSerialization() {
+        return this.sound == ConfiguredSpellSound.DEFAULT && this.propertyHolder.size() == 0;
+    }
+
+    @Override
     public ParticleConfigWidgetProvider buildWidgets(int x, int y, int width, int height) {
         List<DocEntryButton> buttons = new ArrayList<>();
         List<SpellSound> spellSounds = new ArrayList<>(SpellSoundRegistry.getSpellSounds());

--- a/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/SpeedProperty.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/particle/configurations/properties/SpeedProperty.java
@@ -48,7 +48,6 @@ public class SpeedProperty extends BaseProperty<SpeedProperty> {
 
     public SpeedProperty() {
         super();
-
     }
 
     public SpeedProperty(double yMinSpeed, double yMaxSpeed, double minXZ, double xzMaxSpeed) {
@@ -69,6 +68,14 @@ public class SpeedProperty extends BaseProperty<SpeedProperty> {
         this.xzMinSpeed = xzMinSpeed;
         this.xzMaxSpeed = xzMaxSpeed;
         return this;
+    }
+
+    @Override
+    public boolean shouldSkipSerialization() {
+        return yMinSpeed == 0.0 &&
+               xzMinSpeed == 0.0 &&
+               yMaxSpeed == 0.0 &&
+               xzMaxSpeed == 0.0;
     }
 
     public double minY() {


### PR DESCRIPTION
## Description

Skip serializing properties with default values

## Reason for Change

Serialization of `ParticleEmitter#particleOptions` is quite expensive as it is a recursive data structure that has many possible properties. Some of these properties are usually default and can be skipped to save both time and memory spent on networking.

## Related Issues

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [x] I have updated documentation if needed
