### PR TITLE
fix: IOOB when middle clicking empty slot in Spell Book GUI

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GuiSpellBook.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/book/GuiSpellBook.java
@@ -554,8 +554,8 @@ public class GuiSpellBook extends SpellSlottedScreen {
                 CraftingButton cell = craftingCells.get(i);
                 if (cell.slotNum == craftingCell.slotNum) {
                     while (cell.getAbstractSpellPart() == null && i < craftingCells.size()) {
-                        i++;
                         cell = craftingCells.get(i);
+                        i++;
                     }
                     idx = i;
                     continue;


### PR DESCRIPTION
## Description

Fixes an index out-of-bounds error when middle clicking an empty slot that has no non-empty slots after it in the Spell Book GUI.

## Reason for Change

Fixes a crash.

## Related Issues

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
