### PR TITLE
fix: update mod name retrieval for glyphs in tooltips 

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
@@ -12,9 +12,6 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
-import net.neoforged.fml.ModContainer;
-import net.neoforged.fml.ModList;
-import net.neoforged.neoforgespi.language.IModInfo;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedList;
@@ -59,10 +56,10 @@ public class GlyphButton extends ANButton {
             tip.add(spellPart.getBookDescLang());
         } else {
             tip.add(Component.translatable("tooltip.ars_nouveau.hold_shift", Minecraft.getInstance().options.keyShift.getKey().getDisplayName()));
-            var modName = ModList.get()
-                    .getModContainerById(spellPart.getRegistryName().getNamespace())
-                    .map(ModContainer::getModInfo)
-                    .map(IModInfo::getDisplayName).orElse(spellPart.getRegistryName().getNamespace());
+            var modName = spellPart.getGlyph().getCreatorModId(spellPart.getGlyph().getDefaultInstance());
+            if (modName == null) {
+                modName = spellPart.getRegistryName().getNamespace();
+            }
             tip.add(Component.literal(modName).withStyle(ChatFormatting.BLUE));
         }
         if (this.abstractSpellPart instanceof AbstractAugment augment && this.augmentingParent != null) {

--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/UnlockGlyphButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/UnlockGlyphButton.java
@@ -11,9 +11,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.world.item.crafting.RecipeHolder;
-import net.neoforged.fml.ModContainer;
-import net.neoforged.fml.ModList;
-import net.neoforged.neoforgespi.language.IModInfo;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -54,10 +51,10 @@ public class UnlockGlyphButton extends ANButton {
         } else {
             tip.add(Component.translatable("ars_nouveau.tier", spellPart.getConfigTier().value).withStyle(Style.EMPTY.withColor(ChatFormatting.BLUE)));
             tip.add(Component.translatable("tooltip.ars_nouveau.hold_shift", Minecraft.getInstance().options.keyShift.getKey().getDisplayName()));
-            var modName = ModList.get()
-                    .getModContainerById(spellPart.getRegistryName().getNamespace())
-                    .map(ModContainer::getModInfo)
-                    .map(IModInfo::getDisplayName).orElse(spellPart.getRegistryName().getNamespace());
+            var modName = spellPart.getGlyph().getCreatorModId(spellPart.getGlyph().getDefaultInstance());
+            if (modName == null) {
+                modName = spellPart.getRegistryName().getNamespace();
+            }
             tip.add(Component.literal(modName).withStyle(ChatFormatting.BLUE));
         }
     }


### PR DESCRIPTION
Uses neoforge's method that is also used in itemstacks.
Allows NEG (and other possible mods) to register with a different namespace for whatever reason.
Solves the "arsomega" appearing in the book when everywhere else it shows as "Not Enough Glyphs" for example