### PR TITLE
Change Decoy read check

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityDummy.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityDummy.java
@@ -239,7 +239,7 @@ public class EntityDummy extends PathfinderMob implements ISummon, IDispellable 
     public void readAdditionalSaveData(CompoundTag tag) {
         super.readAdditionalSaveData(tag);
         this.ticksLeft = tag.getInt("left");
-        if (getOwnerUUID() != null)
+        if (tag.contains("owner"))
             setOwnerID(tag.getUUID("owner"));
     }
 


### PR DESCRIPTION
## Description

Swaps the getOwnerUUID() != null check before reading the tag into a tag.contains("owner")
Prevents the null error while attempting to render a decoy in a jar.

## Reason for Change
Current
```
    @Nullable
    @Override
    public UUID getOwnerUUID() {
        return this.getEntityData().get(OWNER_UUID).isEmpty() ? this.getUUID() : this.getEntityData().get(OWNER_UUID).get();
    }
```
if the owner uuid is empty, it returns its own uuid
So this piece
```
        if (getOwnerUUID() != null)
            setOwnerID(tag.getUUID("owner"));
```
will try to read anyway

## Related Issues

`[24Nov2025 11:52:46.129] [Render thread/WARN] [net.minecraft.world.entity.EntityType/]: Exception loading entity: 
net.minecraft.ReportedException: Loading entity NBT
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Entity.load(Entity.java:1826) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.EntityType.lambda$create$5(EntityType.java:1103) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.Util.ifElse(Util.java:511) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.EntityType.create(EntityType.java:1101) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.EntityType.loadStaticEntity(EntityType.java:1180) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.EntityType.loadEntityRecursive(EntityType.java:1134) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/ars_nouveau@5.10.6-dim4/com.hollingsworth.arsnouveau.common.block.tile.MobJarTile.loadEntityFromTag(MobJarTile.java:275) ~[ars_nouveau-1.21.1-5.10.6-dim4.jar%23218!/:5.10.6-dim4]
	at TRANSFORMER/ars_nouveau@5.10.6-dim4/com.hollingsworth.arsnouveau.common.block.tile.MobJarTile.getEntity(MobJarTile.java:183) ~[ars_nouveau-1.21.1-5.10.6-dim4.jar%23218!/:5.10.6-dim4]
	at TRANSFORMER/ars_nouveau@5.10.6-dim4/com.hollingsworth.arsnouveau.common.block.tile.MobJarTile.dispatchBehavior(MobJarTile.java:267) ~[ars_nouveau-1.21.1-5.10.6-dim4.jar%23218!/:5.10.6-dim4]
	at TRANSFORMER/ars_nouveau@5.10.6-dim4/com.hollingsworth.arsnouveau.common.block.tile.MobJarTile.tick(MobJarTile.java:105) ~[ars_nouveau-1.21.1-5.10.6-dim4.jar%23218!/:5.10.6-dim4]
	at TRANSFORMER/ars_nouveau@5.10.6-dim4/com.hollingsworth.arsnouveau.common.block.ITickable.tick(ITickable.java:20) ~[ars_nouveau-1.21.1-5.10.6-dim4.jar%23218!/:5.10.6-dim4]
	at TRANSFORMER/ars_nouveau@5.10.6-dim4/com.hollingsworth.arsnouveau.common.block.ITickableBlock.lambda$getTicker$0(ITickableBlock.java:16) ~[ars_nouveau-1.21.1-5.10.6-dim4.jar%23218!/:5.10.6-dim4]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.chunk.LevelChunk$BoundTickingBlockEntity.tick(LevelChunk.java:711) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper.tick(LevelChunk.java:788) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.tickBlockEntities(Level.java:565) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.multiplayer.ClientLevel.tickEntities(ClientLevel.java:282) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.tick(Minecraft.java:1856) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.runTick(Minecraft.java:1161) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.run(Minecraft.java:807) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.main.Main.main(Main.java:230) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
	at MC-BOOTSTRAP/fml_loader@4.0.41/net.neoforged.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:136) ~[loader-4.0.41.jar%23161!/:4.0]
	at MC-BOOTSTRAP/fml_loader@4.0.41/net.neoforged.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:124) ~[loader-4.0.41.jar%23161!/:4.0]
	at MC-BOOTSTRAP/fml_loader@4.0.41/net.neoforged.fml.loading.targets.CommonClientLaunchHandler.runService(CommonClientLaunchHandler.java:32) ~[loader-4.0.41.jar%23161!/:4.0]
	at MC-BOOTSTRAP/fml_loader@4.0.41/net.neoforged.fml.loading.targets.CommonLaunchHandler.lambda$launchService$4(CommonLaunchHandler.java:118) ~[loader-4.0.41.jar%23161!/:4.0]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30) [modlauncher-11.0.5.jar%23166!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-11.0.5.jar%23166!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-11.0.5.jar%23166!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.run(Launcher.java:103) [modlauncher-11.0.5.jar%23166!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.main(Launcher.java:74) [modlauncher-11.0.5.jar%23166!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-11.0.5.jar%23166!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-11.0.5.jar%23166!/:?]
	at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.run(BootstrapLauncher.java:210) [bootstraplauncher-2.0.2.jar:?]
	at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:69) [bootstraplauncher-2.0.2.jar:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
	at io.github.zekerzhayard.forgewrapper.installer.Main.main(Main.java:67) [ForgeWrapper-prism-2025-10-07.jar:prism-2025-10-07]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) [NewLaunch.jar:?]
Caused by: java.lang.NullPointerException: Cannot invoke "net.minecraft.nbt.Tag.getType()" because "p_129234_" is null
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.nbt.NbtUtils.loadUUID(NbtUtils.java:128) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.nbt.CompoundTag.getUUID(CompoundTag.java:256) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	at TRANSFORMER/ars_nouveau@5.10.6-dim4/com.hollingsworth.arsnouveau.common.entity.EntityDummy.readAdditionalSaveData(EntityDummy.java:258) ~[ars_nouveau-1.21.1-5.10.6-dim4.jar%23218!/:5.10.6-dim4]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Entity.load(Entity.java:1815) ~[client-1.21.1-20240808.144430-srg.jar%23194!/:?]
	... 40 more`

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
