### PR TITLE
fix: turret always face west when placed

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/RotatingSpellTurret.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/RotatingSpellTurret.java
@@ -49,23 +49,24 @@ public class RotatingSpellTurret extends BasicSpellTurret {
         Direction orientation = placer == null ? Direction.WEST : Direction.orderedByNearest(placer)[0].getOpposite();
 
         if (!(world.getBlockEntity(pos) instanceof RotatingTurretTile turretTile)) return;
+        // Makes the turret rotate to the right direction right after being placed, otherwise it starts right and rotate to facing west.
         switch (orientation) {
             case DOWN:
-                turretTile.rotationY = -90F;
+                turretTile.neededRotationY = -90F;
                 break;
             case UP:
-                turretTile.rotationY = 90F;
+                turretTile.neededRotationY = 90F;
                 break;
             case NORTH:
-                turretTile.rotationX = 270F;
+                turretTile.neededRotationX = 270F;
                 break;
             case SOUTH:
-                turretTile.rotationX = 90F;
+                turretTile.neededRotationX = 90F;
                 break;
             case WEST:
                 break;
             case EAST:
-                turretTile.rotationX = 180F;
+                turretTile.neededRotationX = 180F;
                 break;
         }
     }


### PR DESCRIPTION
## Description

Rotating spell turrets always face west when placed, to be exact they face the right direction and immediately rotate to west.

Changes the initialization of rotation so the turret starts with default placement and rotates to the intended one.

## Reason for Change

Reduces weirdness on being forced to use the dominion wand with simpler initial placements

## Related Issues

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
