### PR TITLE
wolf variants, ai targeting fixes from the rework

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityAllyVex.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityAllyVex.java
@@ -92,7 +92,7 @@ public class EntityAllyVex extends Vex implements IFollowingSummon, ISummon, IDi
 
         this.goalSelector.addGoal(9, new LookAtPlayerGoal(this, Player.class, 3.0F, 1.0F));
         this.goalSelector.addGoal(10, new LookAtPlayerGoal(this, Mob.class, 8.0F));
-        this.goalSelector.addGoal(2, new FollowSummonerFlyingGoal(this, this.owner, 1.0, 6.0f, 3.0f));
+        this.goalSelector.addGoal(2, new FollowSummonerFlyingGoal(this, this.owner, 1.0, 6.0f, 12.0f));
         this.targetSelector.addGoal(1, new CopyOwnerTargetGoal<>(this));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, Mob.class, 10, false, true,
                 (entity) -> (entity instanceof Mob mob && mob.getTarget() != null &&

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/IFollowingSummon.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/IFollowingSummon.java
@@ -31,17 +31,21 @@ public interface IFollowingSummon {
             if (!(this.mob instanceof IFollowingSummon summon)) return false;
             LivingEntity summoner = summon.getSummoner();
             if (summoner == null) return false;
-            var lastHurtMob = summoner.getLastHurtMob();
-
-            return lastHurtMob != null && summoner != lastHurtMob && !(lastHurtMob instanceof ISummon summon2 && summon2.getOwnerAlt() == summoner);
+            var target = summon.getSummoner().getLastHurtMob();
+            if (target == null) target = summon.getSummoner().getLastHurtByMob();
+            mob.setTarget(target);
+            return target != null && summoner != target && !(target instanceof ISummon summon2 && summon2.getOwnerAlt() == summoner);
         }
 
         /**
          * Execute a one shot task or start executing a continuous task
          */
         public void start() {
-            if (mob instanceof IFollowingSummon summon && summon.getSummoner() != null)
-                mob.setTarget(summon.getSummoner().getLastHurtMob());
+            if (mob instanceof IFollowingSummon summon && summon.getSummoner() != null) {
+                var target = summon.getSummoner().getLastHurtMob();
+                if (target == null) target = summon.getSummoner().getLastHurtByMob();
+                mob.setTarget(target);
+            }
             super.start();
         }
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/SummonSkeleton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/SummonSkeleton.java
@@ -45,7 +45,7 @@ public class SummonSkeleton extends Skeleton implements IFollowingSummon, ISummo
 
     private final RangedBowAttackGoal<SummonSkeleton> bowGoal = new RangedBowAttackGoal<>(this, 1.0D, 20, 15.0F);
 
-    private final MeleeAttackGoal meleeGoal = new MeleeAttackGoal(this, 2.2D, true) {
+    private final MeleeAttackGoal meleeGoal = new MeleeAttackGoal(this, 1.5D, true) {
         /**
          * Reset the task's internal state. Called when this task is interrupted by another one
          */
@@ -127,7 +127,7 @@ public class SummonSkeleton extends Skeleton implements IFollowingSummon, ISummo
 
         this.goalSelector.addGoal(9, new LookAtPlayerGoal(this, Player.class, 3.0F, 1.0F));
         this.goalSelector.addGoal(10, new LookAtPlayerGoal(this, Mob.class, 8.0F));
-        this.goalSelector.addGoal(2, new FollowSummonerGoal(this, this.owner, 1.0, 9.0f, 3.0f));
+        this.goalSelector.addGoal(4, new FollowSummonerGoal(this, this.owner, 1.20, 6.0f, 12.0f));
         this.goalSelector.addGoal(4, new WaterAvoidingRandomStrollGoal(this, 1.0D));
         this.targetSelector.addGoal(2, new HurtByTargetGoal(this, SummonSkeleton.class) {
             @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonWolves.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectSummonWolves.java
@@ -4,9 +4,13 @@ import com.hollingsworth.arsnouveau.api.spell.*;
 import com.hollingsworth.arsnouveau.common.entity.SummonWolf;
 import com.hollingsworth.arsnouveau.common.lib.GlyphLib;
 import com.hollingsworth.arsnouveau.setup.registry.ModEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.animal.WolfVariants;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.ModConfigSpec;
@@ -25,16 +29,19 @@ public class EffectSummonWolves extends AbstractEffect {
 
     @Override
     public void onResolve(HitResult rayTraceResult, Level world, @Nullable LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
-        if (!canSummon(shooter))
+        if (!canSummon(shooter) || shooter == null)
             return;
         Vec3 hit = rayTraceResult.getLocation();
         int ticks = (int) (20 * (GENERIC_INT.get() + EXTEND_TIME.get() * spellStats.getDurationMultiplier()));
         if (ticks <= 0) return;
+        Holder<Biome> holder = world.getBiome(BlockPos.containing(rayTraceResult.getLocation()));
+        var wolfVariant = WolfVariants.getSpawnVariant(world.registryAccess(), holder);
         for (int i = 0; i < 2; i++) {
             SummonWolf wolf = new SummonWolf(ModEntities.SUMMON_WOLF.get(), world);
             wolf.ticksLeft = ticks;
+            wolf.setVariant(wolfVariant);
             wolf.setPos(hit.x(), hit.y(), hit.z());
-            wolf.setTarget(shooter.getLastHurtMob());
+            wolf.setTarget(shooter.getLastHurtMob() == null ? shooter.getLastHurtByMob() : shooter.getLastHurtMob());
             wolf.setAggressive(true);
             wolf.setTame(true, false);
             wolf.tame((Player) shooter);


### PR DESCRIPTION
## Description
These are small bits coming from the #2000 PR, being more of a bugfix + one small parity bit.
If the PR is eventually approved, it will override these changes to avoid conflicts.
* Wolf initial target can be the last mob that hurt the player instead of being always the last one that the player hit.0
* Wolves will take the variant of the biome they're spawned in.
* Lowered the priority of Skeleton and Vex follow goal, fixed the inverted parameters and increased a bit.
* Make the Skeleton and Vex AI target the last mob that hit the player too, making them more reliable bodyguards

## Reason for Change

The summons, aside from the wolf, are terrible to use as defensive summoner playstyle since they only target the last mob hit by the player and won't defend the player if it can't hit back first.

Additionally they are terrible in ranged fight because the maxDist and minDist arguments are swapped so they interrupt their attack to stay close to the player, too close to do anything useful. Wolfs are a bit better just because their goal is not a custom one so the distances are fine.

## Related Issues

Many complaints about their behavior 

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

Note: since the changes are a bit more partial than the full summon rework, there might be small differences in actual behavior.

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
