### PR TITLE
Fix mod-names in book tooltips for real

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/gui/buttons/GlyphButton.java
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedList;
@@ -58,7 +59,7 @@ public class GlyphButton extends ANButton {
             tip.add(Component.translatable("tooltip.ars_nouveau.hold_shift", Minecraft.getInstance().options.keyShift.getKey().getDisplayName()));
             var modName = spellPart.getGlyph().getCreatorModId(spellPart.getGlyph().getDefaultInstance());
             if (modName == null) {
-                modName = spellPart.getRegistryName().getNamespace();
+                modName = StringUtils.capitalize(spellPart.getRegistryName().getNamespace());
             }
             tip.add(Component.literal(modName).withStyle(ChatFormatting.BLUE));
         }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/Glyph.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/Glyph.java
@@ -76,7 +76,7 @@ public class Glyph extends ModItem {
         return ModList.get()
                 .getModContainerById(spellPart.getRegistryName().getNamespace())
                 .map(ModContainer::getModInfo)
-                .map(IModInfo::getDisplayName).orElse(super.getCreatorModId(itemStack));
+                .map(IModInfo::getDisplayName).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/Glyph.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/Glyph.java
@@ -20,7 +20,11 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModList;
+import net.neoforged.neoforgespi.language.IModInfo;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +69,14 @@ public class Glyph extends ModItem {
 
     public @NotNull Component getName() {
         return getName(ItemStack.EMPTY);
+    }
+
+    @Override
+    public @Nullable String getCreatorModId(@NotNull ItemStack itemStack) {
+        return ModList.get()
+                .getModContainerById(spellPart.getRegistryName().getNamespace())
+                .map(ModContainer::getModInfo)
+                .map(IModInfo::getDisplayName).orElse(super.getCreatorModId(itemStack));
     }
 
     @Override


### PR DESCRIPTION
#2011 was resulting in plain modids when the method is not overridden, apparently jei was still using the mod container mapping...
The code should more similar to the original now, simply allowing to change the name returned when the glyph method is changed in the spellpart class.
