### PR TITLE
Fix wololo on relay color setter

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWololo.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWololo.java
@@ -132,7 +132,7 @@ public class EffectWololo extends AbstractEffect {
         BlockPos blockPos = rayTraceResult.getBlockPos();
         BlockEntity blockEntity = world.getBlockEntity(blockPos);
         if (blockEntity instanceof IWololoable tileToDye) {
-            ParticleColor color = spellStats.isRandomized() ? ParticleColor.makeRandomColor(255, 255, 255, shooter.getRandom()) : spellContext.getSpell().color();
+            ParticleColor color = spellStats.isRandomized() ? ParticleColor.makeRandomColor(255, 255, 255, shooter.getRandom()) : spellContext.getSpell().particleTimeline().get(ParticleTimelineRegistry.WOLOLO_TIMELINE).getColor();;
             tileToDye.setColor(color);
         } else {
             ItemStack dyeStack = getDye(shooter, spellStats, spellContext);


### PR DESCRIPTION
## Description

Wololo on blocks was reading from the old color getter, instead of the wololo particle timeline

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
