### PR TITLE
Fix jei recipe bookmark support

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/AlakarkinosRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/AlakarkinosRecipeCategory.java
@@ -16,13 +16,14 @@ import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.apache.commons.lang3.text.WordUtils;
 
 import java.text.DecimalFormat;
 import java.util.Locale;
 import java.util.Optional;
 
-public class AlakarkinosRecipeCategory implements IRecipeCategory<AlakarkinosRecipe> {
+public class AlakarkinosRecipeCategory implements IRecipeCategory<RecipeHolder<AlakarkinosRecipe>> {
     public static float ITEMS_PER_ROW = 7f;
 
     public IDrawable background;
@@ -34,8 +35,8 @@ public class AlakarkinosRecipeCategory implements IRecipeCategory<AlakarkinosRec
     }
 
     @Override
-    public RecipeType<AlakarkinosRecipe> getRecipeType() {
-        return JEIArsNouveauPlugin.ALAKARKINOS_RECIPE_TYPE;
+    public RecipeType<RecipeHolder<AlakarkinosRecipe>> getRecipeType() {
+        return JEIArsNouveauPlugin.ALAKARKINOS_RECIPE_TYPE.get();
     }
 
     @Override
@@ -54,7 +55,8 @@ public class AlakarkinosRecipeCategory implements IRecipeCategory<AlakarkinosRec
     }
 
     @Override
-    public void draw(AlakarkinosRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<AlakarkinosRecipe> recipeHolder, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+        AlakarkinosRecipe recipe = recipeHolder.value();
         Minecraft minecraft = Minecraft.getInstance();
         String prepared = recipe.table().location().getPath().replace("archaeology/", "").replaceAll("_[0-9]", "").replaceAll("_", " ").toLowerCase(Locale.ROOT);
         String name = WordUtils.capitalizeFully(prepared);
@@ -62,7 +64,8 @@ public class AlakarkinosRecipeCategory implements IRecipeCategory<AlakarkinosRec
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, AlakarkinosRecipe recipe, IFocusGroup focuses) {
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<AlakarkinosRecipe> recipeHolder, IFocusGroup focuses) {
+        AlakarkinosRecipe recipe = recipeHolder.value();
         DecimalFormat df = new DecimalFormat("##.##%");
         Optional<LootDrops> lootDrops = recipe.drops();
         if (lootDrops.isEmpty()) return;

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/ApparatusEnchantingRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/ApparatusEnchantingRecipeCategory.java
@@ -14,6 +14,7 @@ import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.enchantment.EnchantmentInstance;
 import net.minecraft.world.level.Level;
 
@@ -26,7 +27,8 @@ public class ApparatusEnchantingRecipeCategory extends EnchantingApparatusRecipe
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, EnchantmentRecipe recipe, IFocusGroup focuses) {
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<EnchantmentRecipe> recipeHolder, IFocusGroup focuses) {
+        EnchantmentRecipe recipe = recipeHolder.value();
         List<Ingredient> inputs = multiProvider.apply(recipe).input();
         double angleBetweenEach = 360.0 / inputs.size();
 
@@ -53,8 +55,8 @@ public class ApparatusEnchantingRecipeCategory extends EnchantingApparatusRecipe
     }
 
     @Override
-    public RecipeType<EnchantmentRecipe> getRecipeType() {
-        return JEIArsNouveauPlugin.ENCHANTING_RECIPE_TYPE;
+    public RecipeType<RecipeHolder<EnchantmentRecipe>> getRecipeType() {
+        return JEIArsNouveauPlugin.ENCHANTING_RECIPE_TYPE.get();
     }
 
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/ArmorUpgradeRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/ArmorUpgradeRecipeCategory.java
@@ -19,6 +19,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -32,7 +33,8 @@ public class ArmorUpgradeRecipeCategory extends EnchantingApparatusRecipeCategor
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, ArmorUpgradeRecipe recipe, IFocusGroup focuses) {
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ArmorUpgradeRecipe> recipeHolder, IFocusGroup focuses) {
+        ArmorUpgradeRecipe recipe = recipeHolder.value();
         MultiProvider provider = multiProvider.apply(recipe);
         List<Ingredient> inputs = provider.input();
         double angleBetweenEach = 360.0 / inputs.size();
@@ -76,12 +78,13 @@ public class ArmorUpgradeRecipeCategory extends EnchantingApparatusRecipeCategor
     }
 
     @Override
-    public RecipeType<ArmorUpgradeRecipe> getRecipeType() {
-        return JEIArsNouveauPlugin.ARMOR_RECIPE_TYPE;
+    public RecipeType<RecipeHolder<ArmorUpgradeRecipe>> getRecipeType() {
+        return JEIArsNouveauPlugin.ARMOR_RECIPE_TYPE.get();
     }
 
     @Override
-    public void draw(ArmorUpgradeRecipe recipe, @NotNull IRecipeSlotsView slotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<ArmorUpgradeRecipe> recipeHolder, @NotNull IRecipeSlotsView slotsView, GuiGraphics graphics, double mouseX, double mouseY) {
+        ArmorUpgradeRecipe recipe = recipeHolder.value();
         Font renderer = Minecraft.getInstance().font;
         graphics.drawString(renderer, Component.translatable("ars_nouveau.tier", 1 + recipe.tier), 0, 0, 10, false);
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/BuddingConversionRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/BuddingConversionRecipeCategory.java
@@ -14,9 +14,10 @@ import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.NotNull;
 
-public class BuddingConversionRecipeCategory implements IRecipeCategory<BuddingConversionRecipe> {
+public class BuddingConversionRecipeCategory implements IRecipeCategory<RecipeHolder<BuddingConversionRecipe>> {
     private final IDrawableAnimated arrow;
     public IDrawable background;
     public IDrawable icon;
@@ -28,8 +29,8 @@ public class BuddingConversionRecipeCategory implements IRecipeCategory<BuddingC
     }
 
     @Override
-    public RecipeType<BuddingConversionRecipe> getRecipeType() {
-        return JEIArsNouveauPlugin.BUDDING_CONVERSION_RECIPE_TYPE;
+    public RecipeType<RecipeHolder<BuddingConversionRecipe>> getRecipeType() {
+        return JEIArsNouveauPlugin.BUDDING_CONVERSION_RECIPE_TYPE.get();
     }
 
     @Override
@@ -48,12 +49,13 @@ public class BuddingConversionRecipeCategory implements IRecipeCategory<BuddingC
     }
 
     @Override
-    public void draw(BuddingConversionRecipe recipe, @NotNull IRecipeSlotsView slotsView, @NotNull GuiGraphics matrixStack, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<BuddingConversionRecipe> recipeHolder, @NotNull IRecipeSlotsView slotsView, @NotNull GuiGraphics matrixStack, double mouseX, double mouseY) {
         arrow.draw(matrixStack, 48, 5);
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, BuddingConversionRecipe recipe, IFocusGroup focuses) {
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<BuddingConversionRecipe> recipeHolder, IFocusGroup focuses) {
+        BuddingConversionRecipe recipe = recipeHolder.value();
         builder.addSlot(RecipeIngredientRole.OUTPUT, 120 - 16 - 6, 4).addIngredient(VanillaTypes.ITEM_STACK, recipe.result().asItem().getDefaultInstance());
         builder.addSlot(RecipeIngredientRole.INPUT, 6, 4).addIngredient(VanillaTypes.ITEM_STACK, recipe.input().asItem().getDefaultInstance());
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/CrushRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/CrushRecipeCategory.java
@@ -15,9 +15,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.NotNull;
 
-public class CrushRecipeCategory implements IRecipeCategory<CrushRecipe> {
+public class CrushRecipeCategory implements IRecipeCategory<RecipeHolder<CrushRecipe>> {
 
     public IDrawable background;
     public IDrawable icon;
@@ -30,8 +31,8 @@ public class CrushRecipeCategory implements IRecipeCategory<CrushRecipe> {
     }
 
     @Override
-    public RecipeType<CrushRecipe> getRecipeType() {
-        return JEIArsNouveauPlugin.CRUSH_RECIPE_TYPE;
+    public RecipeType<RecipeHolder<CrushRecipe>> getRecipeType() {
+        return JEIArsNouveauPlugin.CRUSH_RECIPE_TYPE.get();
     }
 
     @Override
@@ -55,7 +56,8 @@ public class CrushRecipeCategory implements IRecipeCategory<CrushRecipe> {
     }
 
     @Override
-    public void draw(CrushRecipe recipe, @NotNull IRecipeSlotsView slotsView, @NotNull GuiGraphics matrixStack, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<CrushRecipe> recipeHolder, @NotNull IRecipeSlotsView slotsView, @NotNull GuiGraphics matrixStack, double mouseX, double mouseY) {
+        CrushRecipe recipe = recipeHolder.value();
         cachedArrows.draw(matrixStack, 22, 6);
         Font renderer = Minecraft.getInstance().font;
         for (int i = 0; i < recipe.outputs().size(); i++) {
@@ -68,7 +70,8 @@ public class CrushRecipeCategory implements IRecipeCategory<CrushRecipe> {
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, CrushRecipe recipe, IFocusGroup focuses) {
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<CrushRecipe> recipeHolder, IFocusGroup focuses) {
+        CrushRecipe recipe = recipeHolder.value();
         builder.addSlot(RecipeIngredientRole.INPUT, 6, 5).addIngredients(recipe.input());
         for (int i = 0; i < recipe.outputs().size(); i++) {
             CrushRecipe.CrushOutput output = recipe.outputs().get(i);

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/EnchantingApparatusRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/EnchantingApparatusRecipeCategory.java
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.NotNull;
 
 public class EnchantingApparatusRecipeCategory<T extends EnchantingApparatusRecipe> extends MultiInputCategory<T> {
@@ -26,9 +27,9 @@ public class EnchantingApparatusRecipeCategory<T extends EnchantingApparatusReci
     }
 
     @Override
-    public RecipeType<T> getRecipeType() {
+    public RecipeType<RecipeHolder<T>> getRecipeType() {
         //noinspection unchecked
-        return (RecipeType<T>) JEIArsNouveauPlugin.ENCHANTING_APP_RECIPE_TYPE;
+        return (RecipeType<RecipeHolder<T>>) (RecipeType<?>) JEIArsNouveauPlugin.ENCHANTING_APP_RECIPE_TYPE.get();
     }
 
     @Override
@@ -47,7 +48,8 @@ public class EnchantingApparatusRecipeCategory<T extends EnchantingApparatusReci
     }
 
     @Override
-    public void draw(EnchantingApparatusRecipe recipe, @NotNull IRecipeSlotsView slotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<T> recipeHolder, @NotNull IRecipeSlotsView slotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+        EnchantingApparatusRecipe recipe = recipeHolder.value();
         Font renderer = Minecraft.getInstance().font;
         if (recipe.consumesSource())
             guiGraphics.drawString(renderer, Component.translatable("ars_nouveau.source", recipe.sourceCost()), 0, 100, 10, false);

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/GlyphRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/GlyphRecipeCategory.java
@@ -13,6 +13,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 public class GlyphRecipeCategory extends MultiInputCategory<GlyphRecipe> {
 
@@ -26,8 +27,8 @@ public class GlyphRecipeCategory extends MultiInputCategory<GlyphRecipe> {
     }
 
     @Override
-    public RecipeType<GlyphRecipe> getRecipeType() {
-        return JEIArsNouveauPlugin.GLYPH_RECIPE_TYPE;
+    public RecipeType<RecipeHolder<GlyphRecipe>> getRecipeType() {
+        return JEIArsNouveauPlugin.GLYPH_RECIPE_TYPE.get();
     }
 
     @Override
@@ -46,7 +47,8 @@ public class GlyphRecipeCategory extends MultiInputCategory<GlyphRecipe> {
     }
 
     @Override
-    public void draw(GlyphRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<GlyphRecipe> recipeHolder, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+        GlyphRecipe recipe = recipeHolder.value();
         Font renderer = Minecraft.getInstance().font;
         guiGraphics.drawString(renderer, Component.translatable("ars_nouveau.exp", ScribesTile.getLevelsFromExp(recipe.exp)), 0, 100, 10, false);
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/ImbuementRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/ImbuementRecipeCategory.java
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 public class ImbuementRecipeCategory extends MultiInputCategory<ImbuementRecipe> {
 
@@ -26,8 +27,8 @@ public class ImbuementRecipeCategory extends MultiInputCategory<ImbuementRecipe>
     }
 
     @Override
-    public RecipeType<ImbuementRecipe> getRecipeType() {
-        return JEIArsNouveauPlugin.IMBUEMENT_RECIPE_TYPE;
+    public RecipeType<RecipeHolder<ImbuementRecipe>> getRecipeType() {
+        return JEIArsNouveauPlugin.IMBUEMENT_RECIPE_TYPE.get();
     }
 
     @Override
@@ -46,7 +47,8 @@ public class ImbuementRecipeCategory extends MultiInputCategory<ImbuementRecipe>
     }
 
     @Override
-    public void draw(ImbuementRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<ImbuementRecipe> recipeHolder, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+        ImbuementRecipe recipe = recipeHolder.value();
         Font renderer = Minecraft.getInstance().font;
         guiGraphics.drawString(renderer, Component.translatable("ars_nouveau.source", recipe.source), 0, 100, 10, false);
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/JEIArsNouveauPlugin.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/JEIArsNouveauPlugin.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.client.jei;
 
+import com.google.common.base.Suppliers;
 import com.hollingsworth.arsnouveau.ArsNouveau;
 import com.hollingsworth.arsnouveau.api.registry.GlyphRegistry;
 import com.hollingsworth.arsnouveau.api.registry.RitualRegistry;
@@ -36,16 +37,20 @@ import static com.hollingsworth.arsnouveau.client.jei.ScryRitualRecipeCategory.S
 
 @JeiPlugin
 public class JEIArsNouveauPlugin implements IModPlugin {
-    public static final RecipeType<GlyphRecipe> GLYPH_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "glyph_recipe", GlyphRecipe.class);
-    public static final RecipeType<EnchantingApparatusRecipe> ENCHANTING_APP_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "enchanting_apparatus", EnchantingApparatusRecipe.class);
-    public static final RecipeType<EnchantmentRecipe> ENCHANTING_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "enchantment_apparatus", EnchantmentRecipe.class);
-    public static final RecipeType<ArmorUpgradeRecipe> ARMOR_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "armor_upgrade", ArmorUpgradeRecipe.class);
+    public static final Supplier<RecipeType<RecipeHolder<GlyphRecipe>>> GLYPH_RECIPE_TYPE =createFromDeferredVanilla(RecipeRegistry.GLYPH_TYPE);
+    public static final Supplier<RecipeType<RecipeHolder<EnchantingApparatusRecipe>>> ENCHANTING_APP_RECIPE_TYPE = createFromDeferredVanilla(RecipeRegistry.APPARATUS_TYPE);
+    public static final Supplier<RecipeType<RecipeHolder<EnchantmentRecipe>>> ENCHANTING_RECIPE_TYPE = createFromDeferredVanilla(RecipeRegistry.ENCHANTMENT_TYPE);
+    public static final Supplier<RecipeType<RecipeHolder<ArmorUpgradeRecipe>>> ARMOR_RECIPE_TYPE = createFromDeferredVanilla(RecipeRegistry.ARMOR_UPGRADE_TYPE);
 
-    public static final RecipeType<ImbuementRecipe> IMBUEMENT_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "imbuement", ImbuementRecipe.class);
-    public static final RecipeType<CrushRecipe> CRUSH_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "crush", CrushRecipe.class);
-    public static final RecipeType<BuddingConversionRecipe> BUDDING_CONVERSION_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "budding_conversion", BuddingConversionRecipe.class);
-    public static final RecipeType<ScryRitualRecipe> SCRY_RITUAL_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "scry_ritual", ScryRitualRecipe.class);
-    public static final RecipeType<AlakarkinosRecipe> ALAKARKINOS_RECIPE_TYPE = RecipeType.create(ArsNouveau.MODID, "alakarkinos", AlakarkinosRecipe.class);
+    public static final Supplier<RecipeType<RecipeHolder<ImbuementRecipe>>> IMBUEMENT_RECIPE_TYPE = createFromDeferredVanilla(RecipeRegistry.IMBUEMENT_TYPE);
+    public static final Supplier<RecipeType<RecipeHolder<CrushRecipe>>> CRUSH_RECIPE_TYPE = createFromDeferredVanilla(RecipeRegistry.CRUSH_TYPE);
+    public static final Supplier<RecipeType<RecipeHolder<BuddingConversionRecipe>>> BUDDING_CONVERSION_RECIPE_TYPE = createFromDeferredVanilla(RecipeRegistry.BUDDING_CONVERSION_TYPE);
+    public static final Supplier<RecipeType<RecipeHolder<ScryRitualRecipe>>> SCRY_RITUAL_RECIPE_TYPE = createFromDeferredVanilla(RecipeRegistry.SCRY_RITUAL_TYPE);
+    public static final Supplier<RecipeType<RecipeHolder<AlakarkinosRecipe>>> ALAKARKINOS_RECIPE_TYPE = createFromDeferredVanilla(RecipeRegistry.ALAKARKINOS_RECIPE_TYPE);
+
+    private static <R extends Recipe<?>> Supplier<RecipeType<RecipeHolder<R>>> createFromDeferredVanilla(Supplier<? extends net.minecraft.world.item.crafting.RecipeType<R>> deferredVanillaRecipeType) {
+        return Suppliers.memoize(() -> RecipeType.createFromVanilla(deferredVanillaRecipeType.get()));
+    }
 
     @Override
     public @NotNull ResourceLocation getPluginUid() {
@@ -67,68 +72,70 @@ public class JEIArsNouveauPlugin implements IModPlugin {
         );
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void registerRecipes(@NotNull IRecipeRegistration registry) {
-        List<GlyphRecipe> recipeList = new ArrayList<>();
-        List<EnchantingApparatusRecipe> apparatus = new ArrayList<>();
-        List<EnchantmentRecipe> enchantments = new ArrayList<>();
-        List<CrushRecipe> crushRecipes = new ArrayList<>();
-        List<ArmorUpgradeRecipe> armorUpgrades = new ArrayList<>();
+        List<RecipeHolder<GlyphRecipe>> recipeList = new ArrayList<>();
+        List<RecipeHolder<EnchantingApparatusRecipe>> apparatus = new ArrayList<>();
+        List<RecipeHolder<EnchantmentRecipe>> enchantments = new ArrayList<>();
+        List<RecipeHolder<CrushRecipe>> crushRecipes = new ArrayList<>();
+        List<RecipeHolder<ArmorUpgradeRecipe>> armorUpgrades = new ArrayList<>();
 
-        List<ImbuementRecipe> imbuementRecipes = Minecraft.getInstance().level.getRecipeManager().getAllRecipesFor(RecipeRegistry.IMBUEMENT_TYPE.get()).stream().map(RecipeHolder::value).toList();
+        List<RecipeHolder<ImbuementRecipe>> imbuementRecipes = Minecraft.getInstance().level.getRecipeManager().getAllRecipesFor(RecipeRegistry.IMBUEMENT_TYPE.get()).stream().toList();
 
-        List<BuddingConversionRecipe> buddingConversionRecipes = new ArrayList<>();
-        List<ScryRitualRecipe> scryRitualRecipes = new ArrayList<>();
-        List<AlakarkinosRecipe> alakarkinosRecipes = new ArrayList<>();
+        List<RecipeHolder<BuddingConversionRecipe>> buddingConversionRecipes = new ArrayList<>();
+        List<RecipeHolder<ScryRitualRecipe>> scryRitualRecipes = new ArrayList<>();
+        List<RecipeHolder<AlakarkinosRecipe>> alakarkinosRecipes = new ArrayList<>();
 
         RecipeManager manager = Minecraft.getInstance().level.getRecipeManager();
-        for (Recipe<?> i : manager.getRecipes().stream().map(RecipeHolder::value).toList()) {
-            if (i instanceof GlyphRecipe glyphRecipe) {
-                recipeList.add(glyphRecipe);
+        for (RecipeHolder<?> h : manager.getRecipes().stream().toList()) {
+            Recipe<?> i = h.value();
+            if (i instanceof GlyphRecipe) {
+                recipeList.add((RecipeHolder<GlyphRecipe>) h);
             }
-            if (i instanceof EnchantmentRecipe enchantmentRecipe) {
-                enchantments.add(enchantmentRecipe);
-            } else if (i instanceof ArmorUpgradeRecipe upgradeRecipe) {
-                armorUpgrades.add(upgradeRecipe);
+            if (i instanceof EnchantmentRecipe) {
+                enchantments.add((RecipeHolder<EnchantmentRecipe>) h);
+            } else if (i instanceof ArmorUpgradeRecipe) {
+                armorUpgrades.add((RecipeHolder<ArmorUpgradeRecipe>) h);
             } else if (i instanceof EnchantingApparatusRecipe enchantingApparatusRecipe && !enchantingApparatusRecipe.excludeJei()) {
-                apparatus.add(enchantingApparatusRecipe);
+                apparatus.add((RecipeHolder<EnchantingApparatusRecipe>) h);
             }
-            if (i instanceof CrushRecipe crushRecipe) {
-                crushRecipes.add(crushRecipe);
+            if (i instanceof CrushRecipe) {
+                crushRecipes.add((RecipeHolder<CrushRecipe>) h);
             }
-            if (i instanceof BuddingConversionRecipe buddingConversionRecipe) {
-                buddingConversionRecipes.add(buddingConversionRecipe);
+            if (i instanceof BuddingConversionRecipe) {
+                buddingConversionRecipes.add((RecipeHolder<BuddingConversionRecipe>) h);
             }
-            if (i instanceof ScryRitualRecipe scryRitualRecipe) {
-                scryRitualRecipes.add(scryRitualRecipe);
+            if (i instanceof ScryRitualRecipe) {
+                scryRitualRecipes.add((RecipeHolder<ScryRitualRecipe>) h);
             }
-            if (i instanceof AlakarkinosRecipe alakarkinosRecipe) {
-                alakarkinosRecipes.add(alakarkinosRecipe);
+            if (i instanceof AlakarkinosRecipe) {
+                alakarkinosRecipes.add((RecipeHolder<AlakarkinosRecipe>) h);
             }
         }
-        registry.addRecipes(GLYPH_RECIPE_TYPE, recipeList);
-        registry.addRecipes(CRUSH_RECIPE_TYPE, crushRecipes);
-        registry.addRecipes(ENCHANTING_APP_RECIPE_TYPE, apparatus);
-        registry.addRecipes(ENCHANTING_RECIPE_TYPE, enchantments);
-        registry.addRecipes(IMBUEMENT_RECIPE_TYPE, imbuementRecipes);
-        registry.addRecipes(ARMOR_RECIPE_TYPE, armorUpgrades);
-        registry.addRecipes(BUDDING_CONVERSION_RECIPE_TYPE, buddingConversionRecipes);
-        registry.addRecipes(SCRY_RITUAL_RECIPE_TYPE, scryRitualRecipes);
+        registry.addRecipes(GLYPH_RECIPE_TYPE.get(), recipeList);
+        registry.addRecipes(CRUSH_RECIPE_TYPE.get(), crushRecipes);
+        registry.addRecipes(ENCHANTING_APP_RECIPE_TYPE.get(), apparatus);
+        registry.addRecipes(ENCHANTING_RECIPE_TYPE.get(), enchantments);
+        registry.addRecipes(IMBUEMENT_RECIPE_TYPE.get(), imbuementRecipes);
+        registry.addRecipes(ARMOR_RECIPE_TYPE.get(), armorUpgrades);
+        registry.addRecipes(BUDDING_CONVERSION_RECIPE_TYPE.get(), buddingConversionRecipes);
+        registry.addRecipes(SCRY_RITUAL_RECIPE_TYPE.get(), scryRitualRecipes);
         registry.getIngredientManager().removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK, List.of(BlockRegistry.PORTAL_BLOCK.asItem().getDefaultInstance()));
-        registry.addRecipes(ALAKARKINOS_RECIPE_TYPE, alakarkinosRecipes);
+        registry.addRecipes(ALAKARKINOS_RECIPE_TYPE.get(), alakarkinosRecipes);
     }
 
     @Override
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registry) {
-        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.SCRIBES_BLOCK), GLYPH_RECIPE_TYPE);
-        registry.addRecipeCatalyst(new ItemStack(EffectCrush.INSTANCE.glyphItem), CRUSH_RECIPE_TYPE);
-        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.IMBUEMENT_BLOCK), IMBUEMENT_RECIPE_TYPE);
-        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.ENCHANTING_APP_BLOCK), ENCHANTING_APP_RECIPE_TYPE);
-        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.ENCHANTING_APP_BLOCK), ENCHANTING_RECIPE_TYPE);
-        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.ENCHANTING_APP_BLOCK), ARMOR_RECIPE_TYPE);
-        registry.addRecipeCatalyst(new ItemStack(ItemsRegistry.AMETHYST_GOLEM_CHARM), BUDDING_CONVERSION_RECIPE_TYPE);
-        registry.addRecipeCatalyst(RitualRegistry.getRitualItemMap().get(SCRY_RITUAL).asItem().getDefaultInstance(), SCRY_RITUAL_RECIPE_TYPE);
-        registry.addRecipeCatalyst(new ItemStack(ItemsRegistry.ALAKARKINOS_CHARM), ALAKARKINOS_RECIPE_TYPE);
+        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.SCRIBES_BLOCK), GLYPH_RECIPE_TYPE.get());
+        registry.addRecipeCatalyst(new ItemStack(EffectCrush.INSTANCE.glyphItem), CRUSH_RECIPE_TYPE.get());
+        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.IMBUEMENT_BLOCK), IMBUEMENT_RECIPE_TYPE.get());
+        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.ENCHANTING_APP_BLOCK), ENCHANTING_APP_RECIPE_TYPE.get());
+        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.ENCHANTING_APP_BLOCK), ENCHANTING_RECIPE_TYPE.get());
+        registry.addRecipeCatalyst(new ItemStack(BlockRegistry.ENCHANTING_APP_BLOCK), ARMOR_RECIPE_TYPE.get());
+        registry.addRecipeCatalyst(new ItemStack(ItemsRegistry.AMETHYST_GOLEM_CHARM), BUDDING_CONVERSION_RECIPE_TYPE.get());
+        registry.addRecipeCatalyst(RitualRegistry.getRitualItemMap().get(SCRY_RITUAL).asItem().getDefaultInstance(), SCRY_RITUAL_RECIPE_TYPE.get());
+        registry.addRecipeCatalyst(new ItemStack(ItemsRegistry.ALAKARKINOS_CHARM), ALAKARKINOS_RECIPE_TYPE.get());
     }
 
     @Override

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/MultiInputCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/MultiInputCategory.java
@@ -8,13 +8,15 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.phys.Vec2;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Function;
 
-public abstract class MultiInputCategory<T> implements IRecipeCategory<T> {
+public abstract class MultiInputCategory<T extends Recipe<?>> implements IRecipeCategory<RecipeHolder<T>> {
     protected Function<T, MultiProvider> multiProvider;
     protected Vec2 point = new Vec2(48, 13), center = new Vec2(48, 45);
 
@@ -23,8 +25,8 @@ public abstract class MultiInputCategory<T> implements IRecipeCategory<T> {
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, T recipe, IFocusGroup focuses) {
-        MultiProvider provider = multiProvider.apply(recipe);
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<T> recipeHolder, IFocusGroup focuses) {
+        MultiProvider provider = multiProvider.apply(recipeHolder.value());
         List<Ingredient> inputs = provider.input;
         double angleBetweenEach = 360.0 / inputs.size();
         if (provider.optionalCenter != null)

--- a/src/main/java/com/hollingsworth/arsnouveau/client/jei/ScryRitualRecipeCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/jei/ScryRitualRecipeCategory.java
@@ -21,13 +21,13 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.item.crafting.RecipeHolder;import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class ScryRitualRecipeCategory implements IRecipeCategory<ScryRitualRecipe> {
+public class ScryRitualRecipeCategory implements IRecipeCategory<RecipeHolder<ScryRitualRecipe>> {
     public static final ResourceLocation SCRY_RITUAL = ArsNouveau.prefix(RitualLib.SCRYING);
     private final IDrawableAnimated arrow;
     public IDrawable background;
@@ -40,8 +40,8 @@ public class ScryRitualRecipeCategory implements IRecipeCategory<ScryRitualRecip
     }
 
     @Override
-    public RecipeType<ScryRitualRecipe> getRecipeType() {
-        return JEIArsNouveauPlugin.SCRY_RITUAL_RECIPE_TYPE;
+    public RecipeType<RecipeHolder<ScryRitualRecipe>> getRecipeType() {
+        return JEIArsNouveauPlugin.SCRY_RITUAL_RECIPE_TYPE.get();
     }
 
     @Override
@@ -60,13 +60,14 @@ public class ScryRitualRecipeCategory implements IRecipeCategory<ScryRitualRecip
     }
 
     @Override
-    public void draw(ScryRitualRecipe recipe, @NotNull IRecipeSlotsView slotsView, @NotNull GuiGraphics matrixStack, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<ScryRitualRecipe> recipe, @NotNull IRecipeSlotsView slotsView, @NotNull GuiGraphics matrixStack, double mouseX, double mouseY) {
         background.draw(matrixStack, 0, 0);
         arrow.draw(matrixStack, 48, 5);
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, ScryRitualRecipe recipe, IFocusGroup focuses) {
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ScryRitualRecipe> recipeHolder, IFocusGroup focuses) {
+        ScryRitualRecipe recipe = recipeHolder.value();
         List<ItemStack> items = new ArrayList<>();
         for (Holder<Block> blockHolder : BuiltInRegistries.BLOCK.getTagOrEmpty(recipe.highlight())) {
             items.add(blockHolder.value().asItem().getDefaultInstance());


### PR DESCRIPTION
## Description

Fix jei recipe bookmark support

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->

Jei Recipe Bookmark need a recipe id,but mojang move id property from Recipe to RecipeHolder

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated documentation if needed
