### PR TITLE
fix: add loot tables for wall signs

### DIFF
--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/archwood_hanging_wall_sign.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/archwood_hanging_wall_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ars_nouveau:archwood_hanging_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "ars_nouveau:blocks/archwood_hanging_wall_sign"
+}

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/archwood_wall_sign.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/archwood_wall_sign.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ars_nouveau:archwood_sign"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "ars_nouveau:blocks/archwood_wall_sign"
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/DefaultTableProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/DefaultTableProvider.java
@@ -140,7 +140,9 @@ public class DefaultTableProvider extends LootTableProvider {
             registerDropSelf(BlockRegistry.STRIPPED_AWWOOD_PURPLE);
             registerDropDoor(BlockRegistry.ARCHWOOD_DOOR.get());
             registerDropSelf(BlockRegistry.ARCHWOOD_SIGN);
+            registerDropSelf(BlockRegistry.ARCHWOOD_WALL_SIGN);
             registerDropSelf(BlockRegistry.ARCHWOOD_HANGING_SIGN);
+            registerDropSelf(BlockRegistry.ARCHWOOD_HANGING_WALL_SIGN);
             registerDropSelf(BlockRegistry.SOURCE_GEM_BLOCK);
 
             registerDropSelf(BlockRegistry.POTION_MELDER);


### PR DESCRIPTION
## Description

Make wall signs and hanging signs drop themselves when broken.

## Related Issues

https://discord.com/channels/743298050222587978/1447793088004100127/1447793088004100127

## Type of Change

- [/] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

- [/] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [/] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
