### PR TITLE
feat: randomized rotate

### DIFF
--- a/src/generated/resources/assets/ars_nouveau/lang/en_us.json
+++ b/src/generated/resources/assets/ars_nouveau/lang/en_us.json
@@ -388,7 +388,7 @@
   "ars_nouveau.augment_desc.glyph_rotate_glyph_extract": "Applies silk touch when breaking a block.",
   "ars_nouveau.augment_desc.glyph_rotate_glyph_fortune": "Applies fortune when breaking a block.",
   "ars_nouveau.augment_desc.glyph_rotate_glyph_pierce": "Increases the depth of targeted blocks.",
-  "ars_nouveau.augment_desc.glyph_rotate_glyph_randomize": "Adds a chance to not target a block.",
+  "ars_nouveau.augment_desc.glyph_rotate_glyph_randomize": "Applies a random rotation, ignoring axis.",
   "ars_nouveau.augment_desc.glyph_rotate_glyph_sensitive": "Rotates the block on a different axis or forces an entity to rotate their head.",
   "ars_nouveau.augment_desc.glyph_rune_glyph_sensitive": "The rune will use the owner's inventory for pickup and usage.",
   "ars_nouveau.augment_desc.glyph_sense_magic_glyph_amplify": "Increases the level of the effect.",


### PR DESCRIPTION
## Description

Allows Rotate to be randomized.

## Reason for Change

[Players wanted a way to randomly rotate blocks in a build for detailing.
](https://discord.com/channels/743298050222587978/1284562311280988273)

## Related Issues

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated documentation if needed
