### PR TITLE
fix: drygmy always includes entities

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/DrygmyTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/DrygmyTile.java
@@ -134,9 +134,8 @@ public class DrygmyTile extends SummoningTile implements ITooltipProvider, IWand
         Set<ResourceLocation> uniqueEntities;
         this.nearbyEntities = new ArrayList<>();
         if (this.includeEntities) {
-            this.nearbyEntities.addAll(level.getEntitiesOfClass(LivingEntity.class, new AABB(getBlockPos().north(10).west(10).below(6).getBottomCenter(), getBlockPos().south(10).east(10).above(6).getBottomCenter())));
+            this.nearbyEntities = level.getEntitiesOfClass(LivingEntity.class, new AABB(getBlockPos().north(10).west(10).below(6).getBottomCenter(), getBlockPos().south(10).east(10).above(6).getBottomCenter()));
         }
-        this.nearbyEntities = level.getEntitiesOfClass(LivingEntity.class, new AABB(getBlockPos().north(10).west(10).below(6).getBottomCenter(), getBlockPos().south(10).east(10).above(6).getBottomCenter()));
         for (BlockPos b : BlockPos.withinManhattan(getBlockPos(), 10, 10, 10)) {
             if (level.getBlockEntity(b) instanceof MobJarTile mobJarTile && mobJarTile.getEntity() instanceof LivingEntity livingEntity) {
                 nearbyEntities.add(livingEntity);


### PR DESCRIPTION
## Description

Makes DrygmyTile respect the includeEntities flag.

## Reason for Change

Currently, entities are always included regardless of the flag value.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
