### PR TITLE
fix: empty mob jar drops with empty component

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
@@ -316,7 +316,7 @@ public class MobJarTile extends ModdedTile implements ITickable, IDispellable, I
     @Override
     protected void collectImplicitComponents(DataComponentMap.@NotNull Builder pComponents) {
         super.collectImplicitComponents(pComponents);
-        if (this.entityTag != null || this.extraDataTag != null) {
+        if ((this.entityTag != null && !this.entityTag.isEmpty()) || (this.extraDataTag != null && !this.extraDataTag.isEmpty())) {
             pComponents.set(DataComponentRegistry.MOB_JAR, new MobJarData(this.entityTag, this.extraDataTag));
         }
     }


### PR DESCRIPTION
## Description

Continuation of #1886 which failed to check if the relevant components are empty, not just null.

## Reason for Change

Currently placing and breaking an empty mob jar will result in two stacks of what are in essence the same item.

## Related Issues

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
