### PR TITLE
fix: items created by binding and disintegration spawn in the corner

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualBinding.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualBinding.java
@@ -47,7 +47,8 @@ public class RitualBinding extends AbstractRitual {
                         if (familiarHolder.isEntity.test(entity)) {
                             entity.remove(Entity.RemovalReason.DISCARDED);
                             ParticleUtil.spawnPoof((ServerLevel) world, entity.blockPosition());
-                            world.addFreshEntity(new ItemEntity(world, entity.blockPosition().getX(), entity.blockPosition().getY(), entity.blockPosition().getZ(), familiarHolder.getOutputItem()));
+                            var pos = entity.blockPosition().getBottomCenter();
+                            world.addFreshEntity(new ItemEntity(world, pos.x, pos.y, pos.z, familiarHolder.getOutputItem()));
                             world.playSound(null, entity.blockPosition(), SoundEvents.BOOK_PUT, SoundSource.NEUTRAL, 1.0f, 1.0f);
                             ANCriteriaTriggers.rewardNearbyPlayers(ANCriteriaTriggers.FAMILIAR.get(), (ServerLevel) world, entity.blockPosition(), 8);
                         }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualDisintegration.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualDisintegration.java
@@ -60,8 +60,13 @@ public class RitualDisintegration extends AbstractRitual {
                             int numLesser = exp / 3;
                             if ((exp - numLesser * 3) > 0)
                                 numLesser++;
-                            world.addFreshEntity(new ItemEntity(world, m.blockPosition().getX(), m.blockPosition().getY(), m.blockPosition().getZ(), new ItemStack(ItemsRegistry.GREATER_EXPERIENCE_GEM, numGreater)));
-                            world.addFreshEntity(new ItemEntity(world, m.blockPosition().getX(), m.blockPosition().getY(), m.blockPosition().getZ(), new ItemStack(ItemsRegistry.EXPERIENCE_GEM, numLesser)));
+                            var pos = m.blockPosition().getBottomCenter();
+                            if (numGreater > 0) {
+                                world.addFreshEntity(new ItemEntity(world, pos.x, pos.y, pos.z, new ItemStack(ItemsRegistry.GREATER_EXPERIENCE_GEM, numGreater)));
+                            }
+                            if (numLesser > 0) {
+                                world.addFreshEntity(new ItemEntity(world, pos.x, pos.y, pos.z, new ItemStack(ItemsRegistry.EXPERIENCE_GEM, numLesser)));
+                            }
                             didWorkOnce = true;
                         }
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->
Makes items created by binding and disintegration spawn in the center of the block instead of the corner.

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->
Prevents the spawned items from clipping into other blocks

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
