### PR TITLE
[Issue] - Add rotation to archwood trapdoor blockstate variants.

### DIFF
--- a/src/main/resources/assets/ars_nouveau/blockstates/archwood_trapdoor.json
+++ b/src/main/resources/assets/ars_nouveau/blockstates/archwood_trapdoor.json
@@ -1,14 +1,16 @@
 {
   "variants": {
     "facing=east,half=bottom,open=false": {
-      "model": "ars_nouveau:block/archwood_trapdoor_bottom"
+      "model": "ars_nouveau:block/archwood_trapdoor_bottom",
+      "y": 90
     },
     "facing=east,half=bottom,open=true": {
       "model": "ars_nouveau:block/archwood_trapdoor_open",
       "y": 90
     },
     "facing=east,half=top,open=false": {
-      "model": "ars_nouveau:block/archwood_trapdoor_top"
+      "model": "ars_nouveau:block/archwood_trapdoor_top",
+      "y": 90
     },
     "facing=east,half=top,open=true": {
       "model": "ars_nouveau:block/archwood_trapdoor_open",
@@ -27,28 +29,32 @@
       "model": "ars_nouveau:block/archwood_trapdoor_open"
     },
     "facing=south,half=bottom,open=false": {
-      "model": "ars_nouveau:block/archwood_trapdoor_bottom"
+      "model": "ars_nouveau:block/archwood_trapdoor_bottom",
+      "y": 180
     },
     "facing=south,half=bottom,open=true": {
       "model": "ars_nouveau:block/archwood_trapdoor_open",
       "y": 180
     },
     "facing=south,half=top,open=false": {
-      "model": "ars_nouveau:block/archwood_trapdoor_top"
+      "model": "ars_nouveau:block/archwood_trapdoor_top",
+      "y": 180
     },
     "facing=south,half=top,open=true": {
       "model": "ars_nouveau:block/archwood_trapdoor_open",
       "y": 180
     },
     "facing=west,half=bottom,open=false": {
-      "model": "ars_nouveau:block/archwood_trapdoor_bottom"
+      "model": "ars_nouveau:block/archwood_trapdoor_bottom",
+      "y": 270
     },
     "facing=west,half=bottom,open=true": {
       "model": "ars_nouveau:block/archwood_trapdoor_open",
       "y": 270
     },
     "facing=west,half=top,open=false": {
-      "model": "ars_nouveau:block/archwood_trapdoor_top"
+      "model": "ars_nouveau:block/archwood_trapdoor_top",
+      "y": 270
     },
     "facing=west,half=top,open=true": {
       "model": "ars_nouveau:block/archwood_trapdoor_open",


### PR DESCRIPTION
This pull request updates the blockstate definitions for the `archwood_trapdoor` to ensure correct model rotation for different facing directions. The changes add explicit rotation values to the relevant variants in the JSON configuration.

Blockstate configuration improvements:

* Added the `"y"` rotation property to the `archwood_trapdoor` blockstate variants for east, south, and west facings to ensure the trapdoor models are oriented correctly in-game. (`src/main/resources/assets/ars_nouveau/blockstates/archwood_trapdoor.json`) [[1]](diffhunk://#diff-6479626999e23786bb9d60b8adff4c553ad021b10ca5533bd32639d9a91d8becL4-R13) [[2]](diffhunk://#diff-6479626999e23786bb9d60b8adff4c553ad021b10ca5533bd32639d9a91d8becL30-R57)