### PR TITLE
Chimera fixes

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityChimeraProjectile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityChimeraProjectile.java
@@ -14,6 +14,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.EntityHitResult;
+import org.jetbrains.annotations.NotNull;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.animatable.instance.AnimatableInstanceCache;
 import software.bernie.geckolib.animation.AnimatableManager;
@@ -33,6 +34,11 @@ public class EntityChimeraProjectile extends AbstractArrow implements GeoEntity 
     }
 
     @Override
+    protected float getWaterInertia() {
+        return 0.9F;
+    }
+
+    @Override
     public void tick() {
         super.tick();
         if (!level.isClientSide && this.inGroundTime >= 1) {
@@ -41,17 +47,17 @@ public class EntityChimeraProjectile extends AbstractArrow implements GeoEntity 
     }
 
     @Override
-    protected ItemStack getPickupItem() {
+    protected @NotNull ItemStack getPickupItem() {
         return new ItemStack(Items.ARROW);
     }
 
     @Override
-    protected ItemStack getDefaultPickupItem() {
+    protected @NotNull ItemStack getDefaultPickupItem() {
         return new ItemStack(Items.ARROW);
     }
 
     @Override
-    protected boolean tryPickup(Player pPlayer) {
+    protected boolean tryPickup(@NotNull Player pPlayer) {
         return false;
     }
 
@@ -106,7 +112,7 @@ public class EntityChimeraProjectile extends AbstractArrow implements GeoEntity 
     }
 
     @Override
-    protected void doPostHurtEffects(LivingEntity entity) {
+    protected void doPostHurtEffects(@NotNull LivingEntity entity) {
         super.doPostHurtEffects(entity);
         if (!level.isClientSide) {
 
@@ -122,7 +128,7 @@ public class EntityChimeraProjectile extends AbstractArrow implements GeoEntity 
     }
 
     @Override
-    protected boolean canHitEntity(Entity entity) {
+    protected boolean canHitEntity(@NotNull Entity entity) {
         if (entity instanceof EntityChimeraProjectile) {
             return false;
         }
@@ -145,7 +151,7 @@ public class EntityChimeraProjectile extends AbstractArrow implements GeoEntity 
     }
 
     @Override
-    public EntityType<?> getType() {
+    public @NotNull EntityType<?> getType() {
         return ModEntities.ENTITY_CHIMERA_SPIKE.get();
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/chimera/ChimeraLeapRamGoal.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/chimera/ChimeraLeapRamGoal.java
@@ -86,7 +86,7 @@ public class ChimeraLeapRamGoal extends Goal {
                 return;
             }
             breakBlocks();
-            if (boss.onGround()) {
+            if (boss.onGround() || boss.wantsToSwim()) {
                 Path path = boss.getNavigation().createPath(this.boss.getTarget().blockPosition().above(), 1);
                 if (path == null) {
                     return;
@@ -96,8 +96,13 @@ public class ChimeraLeapRamGoal extends Goal {
             attack();
         }
 
+
         if (boss != null && boss.getTarget() != null && hasHit && BlockUtil.distanceFrom(boss.position, boss.getTarget().position) <= 3f) {
             endRam();
+        }
+
+        if (timeCharging >= 200) {  // Add reasonable timeout
+            finished = true;
         }
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/chimera/ChimeraRageGoal.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/goal/chimera/ChimeraRageGoal.java
@@ -57,7 +57,7 @@ public class ChimeraRageGoal extends Goal {
         chimera.resetCooldowns();
         chimera.removeAllEffects();
         chimera.addEffect(new MobEffectInstance(MobEffects.REGENERATION, 100 + 100 * chimera.getPhase(), 3));
-        chimera.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 300 + 300 * chimera.getPhase(), chimera.getPhase()));
+        chimera.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 300 + 300 * chimera.getPhase(), chimera.getPhase() / 2));
         LivingEntity target = chimera.getTarget();
         if (target != null && !target.onGround()) {
             target.removeEffect(MobEffects.SLOW_FALLING);


### PR DESCRIPTION
## Description

Restores the rage mechanic from original chimera, as the current one was missing a timer increase when not reachable.
Makes the spike projectiles not suffer as much from water drag, could be further reduced by setting 0.99 i guess.
Changes to pathfinding logic to allow the special attacks while in water and to let it switch to the water navigation in a more reliable way.
Added RandomStrolls for land and water to make it a bit less stationary when no target has been aquired.
While it prefers to feed on players, it will now also target mobs hitting it ( eventual wilden friendly fire attacks are excluded ) to avoid summons exploits. Might cause it to get angy at turrets.

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)
