### PR TITLE
fix: make double sourcestone slabs drop 2 slab items

### DIFF
--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_alternating_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_alternating_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:gilded_sourcestone_alternating_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:gilded_sourcestone_alternating_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_basketweave_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_basketweave_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:gilded_sourcestone_basketweave_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:gilded_sourcestone_basketweave_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_large_bricks_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_large_bricks_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:gilded_sourcestone_large_bricks_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:gilded_sourcestone_large_bricks_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_mosaic_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_mosaic_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:gilded_sourcestone_mosaic_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:gilded_sourcestone_mosaic_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_small_bricks_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/gilded_sourcestone_small_bricks_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:gilded_sourcestone_small_bricks_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:gilded_sourcestone_small_bricks_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_alternating_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_alternating_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_gilded_sourcestone_alternating_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_gilded_sourcestone_alternating_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_basketweave_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_basketweave_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_gilded_sourcestone_basketweave_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_gilded_sourcestone_basketweave_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_large_bricks_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_large_bricks_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_gilded_sourcestone_large_bricks_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_gilded_sourcestone_large_bricks_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_mosaic_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_mosaic_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_gilded_sourcestone_mosaic_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_gilded_sourcestone_mosaic_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_small_bricks_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_gilded_sourcestone_small_bricks_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_gilded_sourcestone_small_bricks_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_gilded_sourcestone_small_bricks_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_alternating_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_alternating_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_sourcestone_alternating_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_sourcestone_alternating_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_basketweave_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_basketweave_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_sourcestone_basketweave_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_sourcestone_basketweave_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_large_bricks_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_large_bricks_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_sourcestone_large_bricks_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_sourcestone_large_bricks_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_mosaic_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_mosaic_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_sourcestone_mosaic_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_sourcestone_mosaic_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_sourcestone_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_sourcestone_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_small_bricks_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/smooth_sourcestone_small_bricks_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:smooth_sourcestone_small_bricks_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:smooth_sourcestone_small_bricks_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_alternating_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_alternating_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:sourcestone_alternating_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:sourcestone_alternating_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_basketweave_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_basketweave_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:sourcestone_basketweave_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:sourcestone_basketweave_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_large_bricks_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_large_bricks_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:sourcestone_large_bricks_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:sourcestone_large_bricks_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_mosaic_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_mosaic_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:sourcestone_mosaic_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:sourcestone_mosaic_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:sourcestone_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:sourcestone_slab"
         }
       ],

--- a/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_small_bricks_slab.json
+++ b/src/generated/resources/data/ars_nouveau/loot_table/blocks/sourcestone_small_bricks_slab.json
@@ -3,14 +3,28 @@
   "pools": [
     {
       "bonus_rolls": 0.0,
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ],
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "ars_nouveau:sourcestone_small_bricks_slab",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "type": "double"
+                  }
+                }
+              ],
+              "count": 2.0,
+              "function": "minecraft:set_count"
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
           "name": "ars_nouveau:sourcestone_small_bricks_slab"
         }
       ],

--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/DefaultTableProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/DefaultTableProvider.java
@@ -200,7 +200,7 @@ public class DefaultTableProvider extends LootTableProvider {
                 Block block = BuiltInRegistries.BLOCK.get(ArsNouveau.prefix(s + "_stairs"));
                 registerDropSelf(block);
                 Block slab = BuiltInRegistries.BLOCK.get(ArsNouveau.prefix(s + "_slab"));
-                registerDropSelf(slab);
+                registerSlabItemTable(slab);
 
             }
             registerBedCondition(BlockRegistry.ALTERATION_TABLE.get(), AlterationTable.PART, ThreePartBlock.HEAD);


### PR DESCRIPTION
## Description

The doubled version of the various sourcestone slabs currently drop only one slab item when broken. This changes that by generating the loot table via `registerSlabItemTable` instead of `registerDropSelf`.

## Reason for Change

Double slab should drop two slab items, like our archwood slabs and vanilla stone slabs.

## Related Issues

Reported in Discord by `@becca507`:
https://discord.com/channels/743298050222587978/1420335780944941127

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

Break spell on a few sourcestone slabs, doubled and bottom.

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated documentation if needed
