### PR TITLE
fix: make spellbook only sneak-bypass-use on scribe's table

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellBook.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellBook.java
@@ -15,6 +15,7 @@ import com.hollingsworth.arsnouveau.client.gui.utils.RenderUtils;
 import com.hollingsworth.arsnouveau.client.jei.AliasProvider;
 import com.hollingsworth.arsnouveau.client.registry.ModKeyBindings;
 import com.hollingsworth.arsnouveau.client.renderer.item.SpellBookRenderer;
+import com.hollingsworth.arsnouveau.common.block.tile.ScribesTile;
 import com.hollingsworth.arsnouveau.common.capability.IPlayerCap;
 import com.hollingsworth.arsnouveau.common.network.Networking;
 import com.hollingsworth.arsnouveau.common.network.PacketSetCasterSlot;
@@ -110,7 +111,7 @@ public class SpellBook extends ModItem implements GeoItem, ICasterTool, IRadialP
 
     @Override
     public boolean doesSneakBypassUse(@NotNull ItemStack stack, @NotNull LevelReader world, @NotNull BlockPos pos, @NotNull Player player) {
-        return true;
+        return world.getBlockEntity(pos) instanceof ScribesTile;
     }
 
     @Override


### PR DESCRIPTION
## Description

Change the spell book's `doesSneakBypassUse()` method to only return true with the Scribe's Table, not other blocks. This makes it so when sneak-casting a spell on a block with a right-click interaction, only the spell goes off and not the block interaction.

## Reason for Change

If we have a Touch->Break spell, currently casting that spell on a chest[^1] briefly pops up the chest GUI before the chest gets destroyed. With this change, the chest just gets destroyed without the GUI flickering briefly.

Similarly, casting that spell on a containment jar currently inserts the spellbook into the jar (and then the subsequent empty-hand interaction pops it out of the jar again). With this change, the jar just gets destroyed and the spell book remains in our hand.

[^1]: with an empty offhand because the offhand's `doesSneakBypassUse()` would potentially interfere if it doesn't also return true.

## Related Issues

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

I cast some spells on chests and jars as mentioned above, as well as some other vanilla blocks with right-click interactions. I also checked that the following still works:
* Inscribing spells onto parchment using the scribe's table
* Lighting sconces by sneak-casting a Touch->Conjure Magelight spell
* Non-sneak right-click "casting" of Touch->Conjure Magelight/Invisibility/Dispel on Ghostweave
* Using the spell book to set a spell on a turret
* Enchanting the spell book in the enchanting apparatus

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
