### PR TITLE
feat: make bubble ignore boarding cooldown

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/BubbleEntity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/BubbleEntity.java
@@ -4,6 +4,7 @@ import com.hollingsworth.arsnouveau.api.event.EntityPreRemovalEvent;
 import com.hollingsworth.arsnouveau.api.perk.PerkAttributes;
 import com.hollingsworth.arsnouveau.client.particle.ParticleUtil;
 import com.hollingsworth.arsnouveau.common.lib.EntityTags;
+import com.hollingsworth.arsnouveau.common.mixin.EntityAccessor;
 import com.hollingsworth.arsnouveau.setup.registry.ModEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -78,7 +79,13 @@ public class BubbleEntity extends Projectile implements GeoEntity {
 
             if (this.getPassengers().isEmpty()) {
                 for (Entity entity1 : level.getEntities(this, this.getBoundingBox().inflate(0.5f), this::canHitEntity)) {
-                    entity1.startRiding(this);
+                    // ignore boardingCooldown
+                    var accessor = (EntityAccessor) entity1;
+                    var cooldown = accessor.getBoardingCooldown();
+                    accessor.setBoardingCooldown(0);
+                    if (!entity1.startRiding(this)) {
+                        accessor.setBoardingCooldown(cooldown);
+                    }
                 }
             }
         }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/mixin/EntityAccessor.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/mixin/EntityAccessor.java
@@ -1,0 +1,14 @@
+package com.hollingsworth.arsnouveau.common.mixin;
+
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Entity.class)
+public interface EntityAccessor {
+    @Accessor
+    int getBoardingCooldown();
+
+    @Accessor
+    void setBoardingCooldown(int boardingCooldown);
+}

--- a/src/main/resources/ars_nouveau.mixins.json
+++ b/src/main/resources/ars_nouveau.mixins.json
@@ -21,6 +21,7 @@
     "BlockItemAccessor",
     "BrushableBlockEntityAccessor",
     "DamageSourceMixin",
+    "EntityAccessor",
     "EntityMixin",
     "ItemStackMixin",
     "LivingAccessor",


### PR DESCRIPTION
## Description

Make Bubble ignore Entity#boardingCooldown when picking up entities.

## Reason for Change

Entity#boardingCooldown is set to 60 when a non-player entity has its vehicle removed, this makes it quite inconvenient for users of Bubble as their target may completely ignore the Bubble.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
