### PR TITLE
Fix Adjustable Turret direction

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/RotatingSpellTurret.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/RotatingSpellTurret.java
@@ -108,7 +108,7 @@ public class RotatingSpellTurret extends BasicSpellTurret {
                     LivingEntity entity = entityList.get(serverLevel.random.nextInt(entityList.size()));
                     resolver.onCastOnEntity(ItemStack.EMPTY, entity, InteractionHand.MAIN_HAND);
                 } else {
-                    resolver.onCastOnBlock(new BlockHitResult(aimVec, facingDir, BlockPos.containing(aimVec.x(), aimVec.y(), aimVec.z()), true));
+                    resolver.onCastOnBlock(new BlockHitResult(aimVec, facingDir.getOpposite(), BlockPos.containing(aimVec.x(), aimVec.y(), aimVec.z()), true));
                 }
             }
         });


### PR DESCRIPTION
## Description

Adjustable turrets were passing the direction they're facing to the touch method instead of their relative facing.

## Related Issues

Pierce on block placing and block breaking effects had a reversed effect, causing the turret to break itself with touch->break->pierce. Block placing would also go backward.

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)