### PR TITLE
fix: remove unloaded familiars

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarEntity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarEntity.java
@@ -75,13 +75,17 @@ public abstract class FamiliarEntity extends PathfinderMob implements GeoEntity,
         return false;
     }
 
-    // Remove familiars when they are unloaded to prevent familiars becoming forgotten.
     @Override
     public void setRemoved(@NotNull RemovalReason reason) {
         if (reason == RemovalReason.UNLOADED_TO_CHUNK) {
             reason = RemovalReason.DISCARDED;
         }
         super.setRemoved(reason);
+    }
+
+    @Override
+    public boolean shouldBeSaved() {
+        return false;
     }
 
     public double getManaReserveModifier() {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarEntity.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/familiar/FamiliarEntity.java
@@ -75,6 +75,15 @@ public abstract class FamiliarEntity extends PathfinderMob implements GeoEntity,
         return false;
     }
 
+    // Remove familiars when they are unloaded to prevent familiars becoming forgotten.
+    @Override
+    public void setRemoved(@NotNull RemovalReason reason) {
+        if (reason == RemovalReason.UNLOADED_TO_CHUNK) {
+            reason = RemovalReason.DISCARDED;
+        }
+        super.setRemoved(reason);
+    }
+
     public double getManaReserveModifier() {
         return manaReserveModifier;
     }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->
Remove familiars when unloaded to prevent familiars from becoming "forgotten" by the spell book.

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->
Many players have faced the issue of finding familiars that they cannot dismiss from the spellbook. Due to the nature of familiars they also cannot kill them through normal means.

This fix is not perfect as it appears to rely on saves (autosaves included) but its better than the current situation.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

#536 and #1570 

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
