### PR TITLE
feat: remove names when using spell with empty name

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectName.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectName.java
@@ -99,6 +99,7 @@ public class EffectName extends AbstractEffect {
         BlockEntity blockEntity = world.getBlockEntity(pos);
         if (blockEntity instanceof SkullBlockEntity head) {
             head.setOwner(name == null ? null : new ResolvableProfile(Optional.of(name.getString()), Optional.empty(), new PropertyMap()));
+            world.sendBlockUpdated(pos, state, state, 3);
             return;
         }
         if (blockEntity instanceof BaseContainerBlockEntity nameable) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectName.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectName.java
@@ -27,6 +27,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.Set;
@@ -43,20 +44,33 @@ public class EffectName extends AbstractEffect {
     public void onResolveEntity(EntityHitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         Component newName = getName(world, shooter, spellStats, spellContext, resolver);
         Entity entity = rayTraceResult.getEntity();
-        entity.setCustomName(newName);
+
+        ItemStack offhand = shooter.getOffhandItem();
+
+        if (shooter != entity || offhand.isEmpty()) {
+            entity.setCustomName(newName);
+        }
+
         if (entity instanceof Mob mob) {
             mob.setPersistenceRequired();
         } else if (entity instanceof ItemEntity item) {
-            item.getItem().set(DataComponents.CUSTOM_NAME, newName);
+            if (newName == null) {
+                item.getItem().remove(DataComponents.CUSTOM_NAME);
+            } else {
+                item.getItem().set(DataComponents.CUSTOM_NAME, newName);
+            }
         }
 
-        ItemStack offhand = shooter.getOffhandItem();
         if (!offhand.isEmpty()) {
-            offhand.set(DataComponents.CUSTOM_NAME, newName);
+            if (newName == null) {
+                offhand.remove(DataComponents.CUSTOM_NAME);
+            } else {
+                offhand.set(DataComponents.CUSTOM_NAME, newName);
+            }
         }
     }
 
-    public Component getName(Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+    public @Nullable Component getName(Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         Component newName = null;
         InventoryManager manager = spellContext.getCaster().getInvManager();
         SlotReference slotRef = manager.findItem(i -> i.getItem() == Items.NAME_TAG, InteractType.EXTRACT);
@@ -68,7 +82,10 @@ public class EffectName extends AbstractEffect {
             ItemStack stack = StackUtil.getHeldCasterToolOrEmpty(shooter);
             if (stack != ItemStack.EMPTY) {
                 AbstractCaster<?> caster = SpellCasterRegistry.from(stack);
-                newName = Component.literal(caster.getSpellName());
+                String spellName = caster.getSpellName();
+                if (spellName != null && !spellName.isEmpty()) {
+                    newName = Component.literal(spellName);
+                }
             }
         }
         return newName;
@@ -81,11 +98,7 @@ public class EffectName extends AbstractEffect {
         BlockState state = world.getBlockState(pos);
         BlockEntity blockEntity = world.getBlockEntity(pos);
         if (blockEntity instanceof SkullBlockEntity head) {
-            head.setOwner(new ResolvableProfile(Optional.of(name.getString()), Optional.empty(), new PropertyMap()));
-            // TODO AT this
-            // head.updateOwnerProfile();
-            world.sendBlockUpdated(pos, state, state, 3);
-            head.setChanged();
+            head.setOwner(name == null ? null : new ResolvableProfile(Optional.of(name.getString()), Optional.empty(), new PropertyMap()));
             return;
         }
         if (blockEntity instanceof BaseContainerBlockEntity nameable) {
@@ -97,10 +110,14 @@ public class EffectName extends AbstractEffect {
 
         for (Entity entity : world.getEntities(null, new AABB(pos).inflate(0.08))) {
             entity.setCustomName(name);
-            if (entity instanceof Mob mob) {
+            if (entity instanceof Mob mob && mob.hasCustomName()) {
                 mob.setPersistenceRequired();
             } else if (entity instanceof ItemEntity item) {
-                item.getItem().set(DataComponents.CUSTOM_NAME, name);
+                if (name == null) {
+                    item.getItem().remove(DataComponents.CUSTOM_NAME);
+                } else {
+                    item.getItem().set(DataComponents.CUSTOM_NAME, name);
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->
Makes EffectName remove custom names when the spell it is resolved in has no name.

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->
Current behaviour is unexpected, setting names to an empty string. Unnaming is more useful.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
