### PR TITLE
[Hotfix] Use saveOptional for FlyingItem entity

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityFlyingItem.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntityFlyingItem.java
@@ -230,7 +230,7 @@ public class EntityFlyingItem extends ColoredProjectile {
     public void addAdditionalSaveData(CompoundTag compound) {
         super.addAdditionalSaveData(compound);
         if (getStack() != null) {
-            Tag tag = getStack().save(level.registryAccess());
+            Tag tag = getStack().saveOptional(level.registryAccess());
             compound.put("item", tag);
         }
         compound.putInt("age", age);


### PR DESCRIPTION
Switch from save to saveOptional to avoid issues with anything that tries to save the entity while the itemstack on it is empty, even if marked as noSave it can still happen, like for example when used with certain mcfunctions. When the entity is used for source bursts (like with the imbuement chamber) and something that uses entity mcfunctions tries to intercept them (bad mod still to be identified), tps drops to report the serialization errors. 

Safest solution was simply using the saveOptional but an isEmpty guard might have been enough too, the user that reported the bug confirmed that this build avoids the tps drops.