### PR TITLE
fix: make Cut copy uuid

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCut.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectCut.java
@@ -79,7 +79,7 @@ public class EffectCut extends AbstractEffect implements IDamageEffect {
     public void doStrip(BlockPos p, BlockHitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         ItemStack axe = new ItemStack(Items.DIAMOND_AXE);
         applyEnchantments(world, spellStats, axe);
-        Player entity = ANFakePlayer.getPlayer((ServerLevel) world);
+        Player entity = ANFakePlayer.getPlayer((ServerLevel) world, shooter.getUUID());
         entity.setItemInHand(InteractionHand.MAIN_HAND, axe);
         // TODO Replace with AN shears
         if (dupeCheck(world, p)) return;
@@ -96,7 +96,7 @@ public class EffectCut extends AbstractEffect implements IDamageEffect {
             List<ItemStack> items = shearable.onSheared(getPlayer(shooter, (ServerLevel) world), shears, world, p);
             items.forEach(i -> world.addFreshEntity(new ItemEntity(world, p.getX(), p.getY(), p.getZ(), i)));
         }
-        Player entity = ANFakePlayer.getPlayer((ServerLevel) world);
+        Player entity = ANFakePlayer.getPlayer((ServerLevel) world, shooter.getUUID());
         entity.setItemInHand(InteractionHand.MAIN_HAND, shears);
         // TODO Replace with AN shears
         if (dupeCheck(world, p)) return;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->

Makes Cut copy the UUID of the caster when attempting to shear or strip blocks.

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->

Not doing so lead to some claims mods (e.g. FTB Chunks) causing the operation to fail even if the owner of the chunk was the caster.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
