### PR TITLE
Translatable `flavor_text`

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCaster.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCaster.java
@@ -385,6 +385,6 @@ public abstract class AbstractCaster<T extends AbstractCaster<T>> implements Too
             pTooltipAdder.accept(Component.literal(spell.getDisplayString()));
         }
         if (!getFlavorText().isEmpty())
-            pTooltipAdder.accept(Component.literal(getFlavorText()).withStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.BLUE)));
+            pTooltipAdder.accept(Component.translatableWithFallback(getFlavorText(), getFlavorText()).withStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.BLUE)));
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCaster.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCaster.java
@@ -385,6 +385,6 @@ public abstract class AbstractCaster<T extends AbstractCaster<T>> implements Too
             pTooltipAdder.accept(Component.literal(spell.getDisplayString()));
         }
         if (!getFlavorText().isEmpty())
-            pTooltipAdder.accept(Component.translatableWithFallback(getFlavorText(), getFlavorText()).withStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.BLUE)));
+            pTooltipAdder.accept(Component.translatable(getFlavorText()).withStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.BLUE)));
     }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/CasterTome.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/CasterTome.java
@@ -73,7 +73,7 @@ public class CasterTome extends ModItem implements ICasterTool, IManaDiscountEqu
             }
 
             if (!Screen.hasShiftDown() && !caster.getFlavorText().isEmpty())
-                tooltip2.add(Component.translatableWithFallback(caster.getFlavorText(), caster.getFlavorText()).withStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.BLUE)));
+                tooltip2.add(Component.translatable(caster.getFlavorText()).withStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.BLUE)));
 
             tooltip2.add(Component.translatable("tooltip.ars_nouveau.caster_tome"));
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/CasterTome.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/CasterTome.java
@@ -73,7 +73,7 @@ public class CasterTome extends ModItem implements ICasterTool, IManaDiscountEqu
             }
 
             if (!Screen.hasShiftDown() && !caster.getFlavorText().isEmpty())
-                tooltip2.add(Component.literal(caster.getFlavorText()).withStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.BLUE)));
+                tooltip2.add(Component.translatableWithFallback(caster.getFlavorText(), caster.getFlavorText()).withStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.BLUE)));
 
             tooltip2.add(Component.translatable("tooltip.ars_nouveau.caster_tome"));
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->

Add localization support for `flavor_text`

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->

While localizing the Enigmatic Skies modpack, our translation team (VM Chinese Translation Group) discovered that the `flavor_text` used in this modpack does not support translation (more info see PR EnigmaticaModpacks/EnigmaticSkies#139 for details).

You can now use the `flavor_text` translation key directly, though the original method is still supported.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [x] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
