### PR TITLE
fix: jar saving NPE

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
@@ -230,17 +230,24 @@ public class MobJarTile extends ModdedTile implements ITickable, IDispellable, I
 
         // Check both conditions because the entity may have never been loaded on the server side.
         if (entityTag != null || cachedEntity != null) {
-            try {
-                cachedEntity = getEntity();
-                if (cachedEntity != null) {
-                    tag.put("entityTag", saveEntityToTag(cachedEntity));
-                    if (tag.getCompound("entityTag").contains("id")) {
-                        tag.putString("entityId", tag.getCompound("entityTag").getString("id"));
-                    }
+            // We cannot run getEntity when the level is null
+            if (level == null) {
+                if (entityTag != null) {
+                    tag.put("entityTag", entityTag);
                 }
-            } catch (Exception e) {
-                tag.put("entityTag", entityTag);
-                Log.getLogger().warn("Failed to save entity in MobJarTile", e);
+            } else {
+                cachedEntity = getEntity();
+                try {
+                    if (cachedEntity != null) {
+                        tag.put("entityTag", saveEntityToTag(cachedEntity));
+                        if (tag.getCompound("entityTag").contains("id")) {
+                            tag.putString("entityId", tag.getCompound("entityTag").getString("id"));
+                        }
+                    }
+                } catch (Exception e) {
+                    tag.put("entityTag", entityTag);
+                    Log.getLogger().warn("Failed to save entity in MobJarTile", e);
+                }
             }
         }
         if (extraDataTag != null) {

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
@@ -8,6 +8,7 @@ import com.hollingsworth.arsnouveau.common.block.ITickable;
 import com.hollingsworth.arsnouveau.common.block.MobJar;
 import com.hollingsworth.arsnouveau.common.items.data.MobJarData;
 import com.hollingsworth.arsnouveau.common.lib.EntityTags;
+import com.hollingsworth.arsnouveau.common.util.Log;
 import com.hollingsworth.arsnouveau.setup.registry.BlockRegistry;
 import com.hollingsworth.arsnouveau.setup.registry.DataComponentRegistry;
 import net.minecraft.client.Minecraft;
@@ -229,16 +230,17 @@ public class MobJarTile extends ModdedTile implements ITickable, IDispellable, I
 
         // Check both conditions because the entity may have never been loaded on the server side.
         if (entityTag != null || cachedEntity != null) {
-            cachedEntity = getEntity();
-            if (cachedEntity != null) {
-                try {
+            try {
+                cachedEntity = getEntity();
+                if (cachedEntity != null) {
                     tag.put("entityTag", saveEntityToTag(cachedEntity));
                     if (tag.getCompound("entityTag").contains("id")) {
                         tag.putString("entityId", tag.getCompound("entityTag").getString("id"));
                     }
-                } catch (Exception e) {
-                    e.printStackTrace();
                 }
+            } catch (Exception e) {
+                tag.put("entityTag", entityTag);
+                Log.getLogger().warn("Failed to save entity in MobJarTile", e);
             }
         }
         if (extraDataTag != null) {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->
fixes a weird NPE that shouldnt be possible (unless you know why MobJarTile's level would ever be null) but was reported by the ATM team on their official servers

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->
causes a crash when unloading chunks

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
