### PR TITLE
remove `ItemListing` wrapping for villager trades

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
@@ -367,47 +367,47 @@ public class EventHandler {
             List<VillagerTrades.ItemListing> level4 = trades.get(4);
             List<VillagerTrades.ItemListing> level5 = trades.get(5);
 
-            level1.add((trader, rand) -> itemToEmer(trader, BlockRegistry.SOURCEBERRY_BUSH, 16, 16, 2));
-            level1.add((trader, rand) -> itemToEmer(trader, ItemsRegistry.MAGE_FIBER, 16, 16, 2));
+            level1.add(itemToEmer(BlockRegistry.SOURCEBERRY_BUSH, 16, 16, 2));
+            level1.add(itemToEmer(ItemsRegistry.MAGE_FIBER, 16, 16, 2));
 
             for (ItemStack fruit : Ingredient.of(ItemTagProvider.SHADY_WIZARD_FRUITS).getItems()) {
-                level1.add((trader, rand) -> itemToEmer(trader, fruit.getItem(), 6, 16, 2));
+                level1.add(itemToEmer(fruit.getItem(), 6, 16, 2));
             }
 
-            level1.add((trader, rand) -> itemToEmer(trader, Items.AMETHYST_SHARD, 32, 16, 2));
+            level1.add(itemToEmer(Items.AMETHYST_SHARD, 32, 16, 2));
 
-            level1.add((trader, rand) -> emerToItem(trader, ItemsRegistry.SOURCE_BERRY_ROLL, 4, 16, 2));
+            level1.add(emerToItem(ItemsRegistry.SOURCE_BERRY_ROLL, 4, 16, 2));
 
-            level2.add((trader, rand) -> emerToItem(trader, BlockRegistry.GHOST_WEAVE, 1, 8, 2));
-            level2.add((trader, rand) -> emerToItem(trader, BlockRegistry.MIRROR_WEAVE, 1, 8, 2));
-            level2.add((trader, rand) -> emerToItem(trader, BlockRegistry.FALSE_WEAVE, 1, 8, 2));
-            level2.add((trader, rand) -> emerToItem(trader, ItemsRegistry.WARP_SCROLL, 1, 8, 2));
+            level2.add(emerToItem(BlockRegistry.GHOST_WEAVE, 1, 8, 2));
+            level2.add(emerToItem(BlockRegistry.MIRROR_WEAVE, 1, 8, 2));
+            level2.add(emerToItem(BlockRegistry.FALSE_WEAVE, 1, 8, 2));
+            level2.add(emerToItem(ItemsRegistry.WARP_SCROLL, 1, 8, 2));
 
             for (ItemStack wilden : Ingredient.of(ItemTagProvider.WILDEN_DROP_TAG).getItems()) {
-                level2.add((trader, rand) -> itemToEmer(trader, wilden.getItem(), 4, 8, 12));
+                level2.add(itemToEmer(wilden.getItem(), 4, 8, 12));
             }
 
             List<RitualTablet> tablets = new ArrayList<>(RitualRegistry.getRitualItemMap().values());
             for (RitualTablet tablet : tablets) {
                 if (tablet.getDefaultInstance().is(ItemTagProvider.RITUAL_TRADE_BLACKLIST)) continue;
-                level3.add((trader, rand) -> emerToItem(trader, tablet, 4, 1, 12));
+                level3.add(emerToItem(tablet, 4, 1, 12));
             }
 
             for (ItemStack shard : Ingredient.of(ItemTagProvider.SUMMON_SHARDS_TAG).getItems()) {
-                level4.add((trader, rand) -> emerToItem(trader, shard.getItem(), 20, 1, 20));
+                level4.add(emerToItem(shard.getItem(), 20, 1, 20));
             }
-            level5.add((trader, rand) -> emerToItem(trader, ItemsRegistry.SOURCE_BERRY_PIE, 4, 8, 2));
+            level5.add(emerToItem(ItemsRegistry.SOURCE_BERRY_PIE, 4, 8, 2));
             level5.add((trader, rand) -> new MerchantOffer(new ItemCost(Items.EMERALD, 48), DungeonLootTables.getRandomItem(DungeonLootTables.RARE_LOOT), 1, 20, 0.2F));
 
         }
     }
 
-    public static MerchantOffer emerToItem(Entity trader, ItemLike itemLike, int cost, int uses, int exp) {
-        return new VillagerTrades.ItemsForEmeralds(itemLike.asItem(), cost, uses, exp).getOffer(trader, trader.getRandom());
+    public static VillagerTrades.ItemListing emerToItem(ItemLike itemLike, int cost, int uses, int exp) {
+        return new VillagerTrades.ItemsForEmeralds(itemLike.asItem(), cost, uses, exp);
     }
 
-    public static MerchantOffer itemToEmer(Entity trader, ItemLike itemLike, int cost, int uses, int exp) {
-        return new VillagerTrades.EmeraldForItems(itemLike.asItem(), cost, uses, exp).getOffer(trader, trader.getRandom());
+    public static VillagerTrades.ItemListing itemToEmer(ItemLike itemLike, int cost, int uses, int exp) {
+        return new VillagerTrades.EmeraldForItems(itemLike.asItem(), cost, uses, exp);
     }
 
 


### PR DESCRIPTION
## Description

Remove additional wrapping of trades. 

## Reason for Change

I saw that Ars uses `VillagerTrades.ItemsForEmeralds` and `VillagerTrades.EmeraldForItems` to add villager trades but it wraps it again into a lambda which is unnecessary, as this results into other mods like MoreJS to not be able to interact with it. 

The PR removes the wrapping lambdas. 

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [X] Refactor (no functional changes expected)

## Manual Testing Performed

Tested it by removing trades with MoreJS then. As `ItemListing` only exist on server there is no need to explicit test on server.

- [X] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [X] I have tested my changes thoroughly
- [X] I have updated documentation if needed
