### PR TITLE
fix: guard Enchanter's Sword passive cast against re-entry recursion

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/event/EventHandler.java
@@ -92,6 +92,12 @@ import java.util.UUID;
 
 @EventBusSubscriber(modid = ArsNouveau.MODID)
 public class EventHandler {
+    // Re-entry guard for the EnchantersSword passive cast: when the scribed spell itself
+    // produces a LivingDamageEvent.Post (e.g. Touch>Wind Shear / Touch>Explosion held by
+    // a non-player wielder), it must not trigger another passive cast on the same thread,
+    // or we recurse until StackOverflowError.
+    private static final ThreadLocal<Boolean> SWORD_PASSIVE_CAST_REENTRY = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void resourceLoadEvent(AddReloadListenerEvent event) {
         event.addListener(new SimplePreparableReloadListener<>() {
@@ -164,8 +170,19 @@ public class EventHandler {
         if (e.getSource().getEntity() instanceof LivingEntity livingUser) {
             if (livingUser instanceof Player)
                 return;
-            if (livingUser.getItemInHand(InteractionHand.MAIN_HAND).getItem() instanceof EnchantersSword && BlockUtil.distanceFrom(livingUser.position, e.getEntity().position) < 3) {
-                livingUser.getItemInHand(InteractionHand.MAIN_HAND).getItem().hurtEnemy(livingUser.getMainHandItem(), e.getEntity(), livingUser);
+            ItemStack mainHand = livingUser.getMainHandItem();
+            if (mainHand.getItem() instanceof EnchantersSword sword && BlockUtil.distanceFrom(livingUser.position, e.getEntity().position) < 3) {
+                // Probe the re-entry guard only once we're in the sword branch: the recursive
+                // cast re-enters here as the same non-player wielder, so the check still catches
+                // it without paying a ThreadLocal lookup on every damage event.
+                if (SWORD_PASSIVE_CAST_REENTRY.get())
+                    return;
+                SWORD_PASSIVE_CAST_REENTRY.set(Boolean.TRUE);
+                try {
+                    sword.hurtEnemy(mainHand, e.getEntity(), livingUser);
+                } finally {
+                    SWORD_PASSIVE_CAST_REENTRY.set(Boolean.FALSE);
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Adds a thread-local re-entry guard to `EventHandler.livingHurtEvent` so the Enchanter's Sword passive cast cannot recursively trigger itself.

When a **non-player** entity wields an Enchanter's Sword scribed with a damaging spell, `livingHurtEvent` reacts to `LivingDamageEvent.Post` by calling `EnchantersSword.hurtEnemy`, which resolves the scribed spell. If that spell deals damage on the same thread (e.g. `Touch → Wind Shear`), the damage re-publishes `LivingDamageEvent.Post`, which re-enters `livingHurtEvent` and casts again — with no terminating condition.

The guard is set around the passive `hurtEnemy` call and checked *inside* the Enchanter's Sword branch, so the recursive event returns early instead of re-casting, and the common (non-sword) damage path pays no extra cost.

```java
ItemStack mainHand = livingUser.getMainHandItem();
if (mainHand.getItem() instanceof EnchantersSword sword && BlockUtil.distanceFrom(...) < 3) {
    if (SWORD_PASSIVE_CAST_REENTRY.get())
        return;
    SWORD_PASSIVE_CAST_REENTRY.set(Boolean.TRUE);
    try {
        sword.hurtEnemy(mainHand, e.getEntity(), livingUser);
    } finally {
        SWORD_PASSIVE_CAST_REENTRY.set(Boolean.FALSE);
    }
}
```

## Reason for Change

On a dedicated server (observed on `ars_nouveau-1.21.1-5.11.5`) this produced an unbounded self-recursion that crashed the tick loop with `java.lang.StackOverflowError` ("Ticking entity"). The captured stack repeats this cycle until the stack is exhausted:

```
ServerPlayer.hurt()
  Player.actuallyHurt()
    CommonHooks.onLivingDamagePost()              → posts LivingDamageEvent.Post
      EventHandler.livingHurtEvent()              → reacts to the hurt event
        EnchantersSword.hurtEnemy()               → fires the scribed passive cast
          SpellResolver.onCastOnEntity()
            MethodTouch.onCastOnEntity()
              SpellResolver.resolveAllEffects/resume()
                EffectWindshear.onResolveEntity()
                  IDamageEffect.attemptDamage()
                    ServerPlayer.hurt()            ⟲ back to the top
```

Because the passive cast re-enters the very handler that triggers it, a single hit from a non-player Enchanter's Sword wielder cascades into infinite recursion. On our server the resulting `StackOverflowError` took down the world thread; NeoForge then began shutdown, the world-save stalled past 60s, and `ServerWatchdog` force-killed the process. It was a recurring pattern across multiple sessions, not a one-off.

A thread-local guard is the correct scope here: the recursion is fully synchronous on the server thread, so blocking re-entry for the duration of the in-progress passive cast breaks the cycle without affecting the legitimate player-attack cast path (which is gated out earlier by `livingUser instanceof Player`).

## Related Issues

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Reliable Reproduction

The runaway recursion requires the victim to take a **second damage source in the same tick** (fall damage) as the wielder's melee hit. The concurrent source keeps `amount > lastHurt` true, defeating the invulnerability gate that would otherwise absorb the re-published spell damage and let the recursion settle after 1–2 levels.

Steps (`1.21.1`):

1. High-health victim. A villager works well — illagers target it and keep attacking. Boost its health so it survives until the stack overflows (on death `canDamage` turns false and the loop unwinds):
   ```
   /summon minecraft:villager ~ ~ ~ {Health:1000f,attributes:[{id:"minecraft:generic.max_health",base:1000.0d}],PersistenceRequired:1b}
   ```
2. Continuous fall damage via a repeating command-block clock:
   ```
   /tp @e[type=villager,limit=1] ~ ~5 ~
   ```
3. One or more vindicators holding an Enchanter's Sword scribed with `Touch → Crush`:
   ```
   /summon minecraft:vindicator ~ ~ ~ {PersistenceRequired:1b,CanPickUpLoot:1b,HandItems:[{components:{"ars_nouveau:spell_caster":{spells:{0:{color:{r:255,b:180,g:25,id:"ars_nouveau:constant"},recipe:["ars_nouveau:glyph_touch","ars_nouveau:glyph_crush"],name:""}}}},count:1,id:"ars_nouveau:enchanters_sword"},{}]}
   ```
4. Within a few seconds the server thread throws `java.lang.StackOverflowError: Ticking entity`.

With the patch, the re-entrant `livingHurtEvent` returns early and the same setup holds steady.

### Captured Crash (trimmed)

`java.lang.StackOverflowError: Ticking entity` on the server thread, with this cycle repeating until the stack is exhausted (full report from `ars_nouveau-1.21.1-5.11.6`, `Touch → Crush`):

```
java.lang.StackOverflowError: Ticking entity
  ...
  neoforge.common.CommonHooks.onLivingDamagePost(CommonHooks.java:333)   → posts LivingDamageEvent.Post
    LivingEntity.actuallyHurt(LivingEntity.java:1759)
      LivingEntity.hurt(LivingEntity.java:1169)
        ars_nouveau.api.spell.IDamageEffect.attemptDamage(IDamageEffect.java:64)
          ars_nouveau.common.spell.effect.EffectCrush.onResolveEntity(EffectCrush.java:58)
            ars_nouveau.api.spell.SpellResolver.resume / resolveAllEffects / onResolveEffect
              ars_nouveau.common.spell.method.MethodTouch.onCastOnEntity(MethodTouch.java:68)
                ars_nouveau.common.items.EnchantersSword.hurtEnemy(EnchantersSword.java:110)
                  ars_nouveau.common.event.EventHandler.livingHurtEvent(EventHandler.java:168)  ⟲ posts again
```

```
-- Entity being ticked --
  Entity Type: minecraft:zombie
  Level game mode: creative
  Minecraft Version: 1.21.1 / NeoForge 21.1.233
```

## Manual Testing Performed

The crash was captured from a live dedicated server (server-side `StackOverflowError`, stack trace above). The fix has been verified by tracing the recursion in the captured stack and confirming the guard breaks the cycle at `livingHurtEvent`. In-game runtime verification of the patched build is still recommended (reproduce with a non-player mob holding an Enchanter's Sword scribed with `Touch → Wind Shear`).

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
