### PR TITLE
fix: add category hierarchies to json export

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/documentation/DocCategory.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/documentation/DocCategory.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.api.documentation;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.hollingsworth.arsnouveau.api.documentation.entry.DocEntry;
 import com.hollingsworth.arsnouveau.api.documentation.export.DocExporter;
@@ -61,6 +62,15 @@ public record DocCategory(ResourceLocation id, ItemStack renderIcon, int order, 
         object.addProperty(DocExporter.ID_PROPERTY, id.toString());
         object.addProperty(DocExporter.ORDER_PROPERTY, order);
         object.addProperty(DocExporter.TITLE_PROPERTY, getTitle().getString());
+
+        JsonArray parentJsons = new JsonArray();
+        parents.stream().sorted().forEach(category -> parentJsons.add(category.id().toString()));
+        object.add("parents", parentJsons);
+
+        JsonArray subCategoryJsons = new JsonArray();
+        subCategories.stream().sorted().forEach(category -> subCategoryJsons.add(category.id().toString()));
+        object.add("sub_categories", subCategoryJsons);
+
         return object;
     }
 }


### PR DESCRIPTION
## Description

Category hierarchies were missing in the JSON export for the documentation.

## Reason for Change

Allows detecting sub-categories and parent categories in the new web-wiki

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
