### PR TITLE
feat: spell parchments copy timelines on interact

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/ITimelined.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/ITimelined.java
@@ -1,0 +1,7 @@
+package com.hollingsworth.arsnouveau.api.spell;
+
+import com.hollingsworth.arsnouveau.api.particle.timelines.IParticleTimeline;
+
+public interface ITimelined<T extends IParticleTimeline<T>> {
+    T getTimeline();
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/LightTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/LightTile.java
@@ -85,4 +85,8 @@ public class LightTile extends ModdedTile implements ITickable, IWololoable {
     public ParticleColor getColor() {
         return color;
     }
+
+    public LightTimeline getTimeline() {
+        return timeline;
+    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/LightTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/LightTile.java
@@ -8,6 +8,7 @@ import com.hollingsworth.arsnouveau.api.particle.timelines.LightTimeline;
 import com.hollingsworth.arsnouveau.api.particle.timelines.TimelineEntryData;
 import com.hollingsworth.arsnouveau.api.registry.ParticleColorRegistry;
 import com.hollingsworth.arsnouveau.api.registry.ParticlePropertyRegistry;
+import com.hollingsworth.arsnouveau.api.spell.ITimelined;
 import com.hollingsworth.arsnouveau.api.util.IWololoable;
 import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
 import com.hollingsworth.arsnouveau.client.registry.ModParticles;
@@ -23,7 +24,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec2;
 import org.jetbrains.annotations.NotNull;
 
-public class LightTile extends ModdedTile implements ITickable, IWololoable {
+public class LightTile extends ModdedTile implements ITickable, IWololoable, ITimelined<LightTimeline> {
     protected LightTimeline timeline = new LightTimeline();
     public ParticleColor color = ParticleColor.defaultParticleColor();
     public ParticleEmitter particleEmitter;
@@ -86,6 +87,7 @@ public class LightTile extends ModdedTile implements ITickable, IWololoable {
         return color;
     }
 
+    @Override
     public LightTimeline getTimeline() {
         return timeline;
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ParticleTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ParticleTile.java
@@ -72,4 +72,8 @@ public class ParticleTile extends ModdedTile implements ITickable {
         this.particleEmitter = new ParticleEmitter(() -> this.getBlockPos().getCenter(), () -> new Vec2(0, 0), timeline.onTickEffect);
         updateBlock();
     }
+
+    public PrestidigitationTimeline getTimeline() {
+        return timeline;
+    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ParticleTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ParticleTile.java
@@ -2,6 +2,7 @@ package com.hollingsworth.arsnouveau.common.block.tile;
 
 import com.hollingsworth.arsnouveau.api.particle.ParticleEmitter;
 import com.hollingsworth.arsnouveau.api.particle.timelines.PrestidigitationTimeline;
+import com.hollingsworth.arsnouveau.api.spell.ITimelined;
 import com.hollingsworth.arsnouveau.common.block.ITickable;
 import com.hollingsworth.arsnouveau.common.util.ANCodecs;
 import com.hollingsworth.arsnouveau.setup.registry.BlockRegistry;
@@ -14,7 +15,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec2;
 import org.jetbrains.annotations.NotNull;
 
-public class ParticleTile extends ModdedTile implements ITickable {
+public class ParticleTile extends ModdedTile implements ITickable, ITimelined<PrestidigitationTimeline> {
     protected PrestidigitationTimeline timeline = new PrestidigitationTimeline();
     public ParticleEmitter particleEmitter;
     public boolean isTemporary;
@@ -73,6 +74,7 @@ public class ParticleTile extends ModdedTile implements ITickable {
         updateBlock();
     }
 
+    @Override
     public PrestidigitationTimeline getTimeline() {
         return timeline;
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/SconceTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/SconceTile.java
@@ -146,4 +146,8 @@ public class SconceTile extends ModdedTile implements ILightable, ITickable, IDi
     public ParticleColor getColor() {
         return color;
     }
+
+    public LightTimeline getTimeline() {
+        return timeline;
+    }
 }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/SconceTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/SconceTile.java
@@ -11,6 +11,7 @@ import com.hollingsworth.arsnouveau.api.registry.ParticleColorRegistry;
 import com.hollingsworth.arsnouveau.api.registry.ParticlePropertyRegistry;
 import com.hollingsworth.arsnouveau.api.registry.ParticleTimelineRegistry;
 import com.hollingsworth.arsnouveau.api.spell.ILightable;
+import com.hollingsworth.arsnouveau.api.spell.ITimelined;
 import com.hollingsworth.arsnouveau.api.spell.SpellContext;
 import com.hollingsworth.arsnouveau.api.spell.SpellStats;
 import com.hollingsworth.arsnouveau.api.util.IWololoable;
@@ -37,7 +38,7 @@ import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
-public class SconceTile extends ModdedTile implements ILightable, ITickable, IDispellable, IWololoable {
+public class SconceTile extends ModdedTile implements ILightable, ITickable, IDispellable, IWololoable, ITimelined<LightTimeline> {
     protected LightTimeline timeline = new LightTimeline();
     protected ParticleColor color = ParticleColor.defaultParticleColor();
     public boolean lit;
@@ -147,6 +148,7 @@ public class SconceTile extends ModdedTile implements ILightable, ITickable, IDi
         return color;
     }
 
+    @Override
     public LightTimeline getTimeline() {
         return timeline;
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellParchment.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellParchment.java
@@ -1,15 +1,14 @@
 package com.hollingsworth.arsnouveau.common.items;
 
 import com.hollingsworth.arsnouveau.api.item.ICasterTool;
-import com.hollingsworth.arsnouveau.api.particle.timelines.BaseTimeline;
+import com.hollingsworth.arsnouveau.api.particle.timelines.IParticleTimeline;
 import com.hollingsworth.arsnouveau.api.registry.SpellCasterRegistry;
 import com.hollingsworth.arsnouveau.api.spell.AbstractCaster;
+import com.hollingsworth.arsnouveau.api.spell.ITimelined;
 import com.hollingsworth.arsnouveau.api.spell.SpellCaster;
+import com.hollingsworth.arsnouveau.api.util.IWololoable;
 import com.hollingsworth.arsnouveau.client.gui.SpellTooltip;
 import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
-import com.hollingsworth.arsnouveau.common.block.tile.LightTile;
-import com.hollingsworth.arsnouveau.common.block.tile.ParticleTile;
-import com.hollingsworth.arsnouveau.common.block.tile.SconceTile;
 import com.hollingsworth.arsnouveau.setup.config.Config;
 import com.hollingsworth.arsnouveau.setup.registry.DataComponentRegistry;
 import com.hollingsworth.arsnouveau.setup.registry.ItemsRegistry;
@@ -71,27 +70,13 @@ public class SpellParchment extends ModItem implements ICasterTool {
     }
 
     public InteractionResult copyTimeline(ServerPlayer player, ServerLevel level, ItemStack hand, BlockEntity tile) {
-        //noinspection rawtypes
-        BaseTimeline timeline;
-        ParticleColor color;
-
-        switch (tile) {
-            case SconceTile sconce -> {
-                timeline = sconce.getTimeline();
-                color = sconce.getColor();
-            }
-            case LightTile light -> {
-                timeline = light.getTimeline();
-                color = light.getColor();
-            }
-            case ParticleTile particle -> {
-                timeline = particle.getTimeline();
-                color = ParticleColor.defaultParticleColor();
-            }
-            case null, default -> {
-                return InteractionResult.PASS;
-            }
+        if (!(tile instanceof ITimelined<?> timelined)) {
+            return InteractionResult.PASS;
         }
+
+        //noinspection rawtypes
+        IParticleTimeline timeline = timelined.getTimeline();
+        ParticleColor color = tile instanceof IWololoable wololoable ? wololoable.getColor() : ParticleColor.defaultParticleColor();
 
         ItemStack stack = hand.copyWithCount(1);
         AbstractCaster<?> caster = SpellCasterRegistry.from(stack);
@@ -101,14 +86,14 @@ public class SpellParchment extends ModItem implements ICasterTool {
 
         //noinspection unchecked
         var newTimeline = caster.getSpell().particleTimeline().put(timeline.getType(), timeline);
-        caster.setSpell(caster.getSpell().withTimeline(newTimeline)).saveToStack(stack);
+        caster.setSpell(caster.getSpell().withColor(color).withTimeline(newTimeline)).saveToStack(stack);
+        
+        if (!player.hasInfiniteMaterials()) {
+            hand.shrink(1);
+        }
 
         if (!player.addItem(stack)) {
             level.addFreshEntity(new ItemEntity(level, player.getX(), player.getY(), player.getZ(), stack));
-        }
-
-        if (!player.hasInfiniteMaterials()) {
-            hand.shrink(1);
         }
 
         return InteractionResult.SUCCESS;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellParchment.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/SpellParchment.java
@@ -1,19 +1,31 @@
 package com.hollingsworth.arsnouveau.common.items;
 
 import com.hollingsworth.arsnouveau.api.item.ICasterTool;
+import com.hollingsworth.arsnouveau.api.particle.timelines.BaseTimeline;
+import com.hollingsworth.arsnouveau.api.registry.SpellCasterRegistry;
 import com.hollingsworth.arsnouveau.api.spell.AbstractCaster;
 import com.hollingsworth.arsnouveau.api.spell.SpellCaster;
 import com.hollingsworth.arsnouveau.client.gui.SpellTooltip;
+import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
+import com.hollingsworth.arsnouveau.common.block.tile.LightTile;
+import com.hollingsworth.arsnouveau.common.block.tile.ParticleTile;
+import com.hollingsworth.arsnouveau.common.block.tile.SconceTile;
 import com.hollingsworth.arsnouveau.setup.config.Config;
 import com.hollingsworth.arsnouveau.setup.registry.DataComponentRegistry;
 import com.hollingsworth.arsnouveau.setup.registry.ItemsRegistry;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -39,6 +51,67 @@ public class SpellParchment extends ModItem implements ICasterTool {
     public void appendHoverText(@NotNull ItemStack stack, @NotNull TooltipContext context, @NotNull List<Component> tooltip2, @NotNull TooltipFlag flagIn) {
         stack.addToTooltip(DataComponentRegistry.SPELL_CASTER, context, tooltip2::add, flagIn);
         super.appendHoverText(stack, context, tooltip2, flagIn);
+    }
+    
+    @Override
+    public @NotNull InteractionResult useOn(UseOnContext pContext) {
+        if (!(pContext.getPlayer() instanceof ServerPlayer player) || !(pContext.getLevel() instanceof ServerLevel level)) {
+            return super.useOn(pContext);
+        }
+
+        var tile = level.getBlockEntity(pContext.getClickedPos());
+        var hand = pContext.getItemInHand();
+        
+        InteractionResult result = copyTimeline(player, level, hand, tile);
+        if (result.consumesAction()) {
+            return result;
+        }
+
+        return super.useOn(pContext);
+    }
+
+    public InteractionResult copyTimeline(ServerPlayer player, ServerLevel level, ItemStack hand, BlockEntity tile) {
+        //noinspection rawtypes
+        BaseTimeline timeline;
+        ParticleColor color;
+
+        switch (tile) {
+            case SconceTile sconce -> {
+                timeline = sconce.getTimeline();
+                color = sconce.getColor();
+            }
+            case LightTile light -> {
+                timeline = light.getTimeline();
+                color = light.getColor();
+            }
+            case ParticleTile particle -> {
+                timeline = particle.getTimeline();
+                color = ParticleColor.defaultParticleColor();
+            }
+            case null, default -> {
+                return InteractionResult.PASS;
+            }
+        }
+
+        ItemStack stack = hand.copyWithCount(1);
+        AbstractCaster<?> caster = SpellCasterRegistry.from(stack);
+        if (caster == null) {
+            return InteractionResult.FAIL;
+        }
+
+        //noinspection unchecked
+        var newTimeline = caster.getSpell().particleTimeline().put(timeline.getType(), timeline);
+        caster.setSpell(caster.getSpell().withTimeline(newTimeline)).saveToStack(stack);
+
+        if (!player.addItem(stack)) {
+            level.addFreshEntity(new ItemEntity(level, player.getX(), player.getY(), player.getZ(), stack));
+        }
+
+        if (!player.hasInfiniteMaterials()) {
+            hand.shrink(1);
+        }
+
+        return InteractionResult.SUCCESS;
     }
 
     @Override


### PR DESCRIPTION
## Description

makes spell parchments copy light/prestidigitation timelines when used on an existing magelight/prestidigitation tile

## Reason for Change

> I would love if we could right click a spell parchment on an existing mage light or prestidigitation block to copy the spell particle settings. Right now if you make one-off mage lights with certain effects, it may be hard to get back to those settings if you want to make another
-Zieg

https://discord.com/channels/743298050222587978/1499463010006073426

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
