### PR TITLE
Adds more context to the filter methods

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractFilter.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractFilter.java
@@ -37,14 +37,13 @@ public abstract class AbstractFilter extends AbstractEffect implements IFilter {
 
     @Override
     public void onResolveEntity(EntityHitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
-        if (!shouldResolveOnEntity(rayTraceResult, world)) spellContext.setCanceled(true, CancelReason.FILTER_FAILED);
+        if (!shouldResolveOnEntity(rayTraceResult, world, spellStats, spellContext, resolver)) spellContext.setCanceled(true, CancelReason.FILTER_FAILED);
     }
 
     @Override
     public void onResolveBlock(BlockHitResult rayTraceResult, Level world, @NotNull LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
-        if (!shouldResolveOnBlock(rayTraceResult, world)) spellContext.setCanceled(true, CancelReason.FILTER_FAILED);
+        if (!shouldResolveOnBlock(rayTraceResult, world, spellStats, spellContext, resolver)) spellContext.setCanceled(true, CancelReason.FILTER_FAILED);
     }
-
 
     @Override
     public DocAssets.BlitInfo getTypeIcon() {

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/IFilter.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/IFilter.java
@@ -1,94 +1,33 @@
 package com.hollingsworth.arsnouveau.api.spell;
 
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
-import net.minecraft.world.phys.Vec3;
 
-/**
- * This interface is intended to set a common standard between addons to make and use glyphs that acts as filters. The main mod never checks for filters.
- */
 public interface IFilter {
 
-    /**
-     * Whether the filter should allow the block hit
-     */
+    @Deprecated(forRemoval = true)
     boolean shouldResolveOnBlock(BlockHitResult target, Level level);
 
-    /**
-     * Default method that wraps the position/direction to call the actual method
-     */
-    default boolean shouldResolveOnBlock(BlockPos pos, Direction direction, Level level) {
-        return shouldResolveOnBlock(
-                new BlockHitResult(new Vec3(pos.getX(), pos.getY(), pos.getZ()), direction, pos, false)
-                , level);
-    }
-
-    /**
-     * Whether the filter should allow the entity hit
-     */
+    @Deprecated(forRemoval = true)
     boolean shouldResolveOnEntity(EntityHitResult target, Level level);
 
-    /**
-     * Default method that wraps an entity to call the actual method
-     */
-    default boolean shouldResolveOnEntity(Entity entity, Level level) {
-        return shouldResolveOnEntity(new EntityHitResult(entity), level);
-    }
-
-    /**
-     * @param rayTraceResult block or entity about to be affected by the spell
-     * @return true if the glyph filter pass, false if the filter blocks
-     */
+    @Deprecated(forRemoval = true)
     default boolean shouldAffect(HitResult rayTraceResult, Level level) {
         if (rayTraceResult instanceof BlockHitResult block) return shouldResolveOnBlock(block, level);
         else if (rayTraceResult instanceof EntityHitResult entity) return shouldResolveOnEntity(entity, level);
         else return false;
     }
 
-
-    /*
-      Advanced versions, fallback to classic methods
-     */
-
-    /**
-     * Whether the filter should allow the block hit
-     */
-    default boolean shouldResolveOnBlock(BlockHitResult target, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver){
+    default boolean shouldResolveOnBlock(BlockHitResult target, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         return shouldResolveOnBlock(target, level);
     }
 
-    /**
-     * Default method that wraps the position/direction to call the actual method
-     */
-    default boolean shouldResolveOnBlock(BlockPos pos, Direction direction, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
-        return shouldResolveOnBlock(
-                new BlockHitResult(new Vec3(pos.getX(), pos.getY(), pos.getZ()), direction, pos, false)
-                , level, spellStats, spellContext, resolver);
-    }
-
-    /**
-     * Whether the filter should allow the entity hit
-     */
     default boolean shouldResolveOnEntity(EntityHitResult target, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         return shouldResolveOnEntity(target, level);
     }
 
-    /**
-     * Default method that wraps an entity to call the actual method
-     */
-    default boolean shouldResolveOnEntity(Entity entity, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
-        return shouldResolveOnEntity(new EntityHitResult(entity), level, spellStats, spellContext, resolver);
-    }
-
-    /**
-     * @param rayTraceResult block or entity about to be affected by the spell
-     * @return true if the glyph filter pass, false if the filter blocks
-     */
     default boolean shouldAffect(HitResult rayTraceResult, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
         if (rayTraceResult instanceof BlockHitResult block)
             return shouldResolveOnBlock(block, level, spellStats, spellContext, resolver);

--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/IFilter.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/IFilter.java
@@ -50,4 +50,51 @@ public interface IFilter {
         else return false;
     }
 
+
+    /*
+      Advanced versions, fallback to classic methods
+     */
+
+    /**
+     * Whether the filter should allow the block hit
+     */
+    default boolean shouldResolveOnBlock(BlockHitResult target, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver){
+        return shouldResolveOnBlock(target, level);
+    }
+
+    /**
+     * Default method that wraps the position/direction to call the actual method
+     */
+    default boolean shouldResolveOnBlock(BlockPos pos, Direction direction, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+        return shouldResolveOnBlock(
+                new BlockHitResult(new Vec3(pos.getX(), pos.getY(), pos.getZ()), direction, pos, false)
+                , level, spellStats, spellContext, resolver);
+    }
+
+    /**
+     * Whether the filter should allow the entity hit
+     */
+    default boolean shouldResolveOnEntity(EntityHitResult target, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+        return shouldResolveOnEntity(target, level);
+    }
+
+    /**
+     * Default method that wraps an entity to call the actual method
+     */
+    default boolean shouldResolveOnEntity(Entity entity, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+        return shouldResolveOnEntity(new EntityHitResult(entity), level, spellStats, spellContext, resolver);
+    }
+
+    /**
+     * @param rayTraceResult block or entity about to be affected by the spell
+     * @return true if the glyph filter pass, false if the filter blocks
+     */
+    default boolean shouldAffect(HitResult rayTraceResult, Level level, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver) {
+        if (rayTraceResult instanceof BlockHitResult block)
+            return shouldResolveOnBlock(block, level, spellStats, spellContext, resolver);
+        else if (rayTraceResult instanceof EntityHitResult entity)
+            return shouldResolveOnEntity(entity, level, spellStats, spellContext, resolver);
+        else return false;
+    }
+
 }


### PR DESCRIPTION
Adds the trio of SpellStats / SpellContext / SpellResolver to the methods used by filters as the current implementation of IFilter doesn't carry on augments and other data.
Old methods are preserved and used as fallback for retrocompatibility and simpler filters.
