### PR TITLE
feat: containment jar item capture blacklist

### DIFF
--- a/src/generated/resources/data/ars_nouveau/tags/item/jar_item_blacklist.json
+++ b/src/generated/resources/data/ars_nouveau/tags/item/jar_item_blacklist.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#ars_nouveau:interact_jar_blacklist"
+  ]
+}

--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/ItemTagProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/ItemTagProvider.java
@@ -237,6 +237,7 @@ public class ItemTagProvider extends IntrinsicHolderTagsProvider<Item> {
         this.tag(Tags.Items.CHESTS).add(BlockRegistry.ARCHWOOD_CHEST.asItem());
         this.tag(Tags.Items.CHESTS_WOODEN).add(BlockRegistry.ARCHWOOD_CHEST.asItem());
         this.tag(JAR_ITEM_BLACKLIST);
+        this.tag(JAR_ITEM_CAPTURE_BLACKLIST).addTag(JAR_ITEM_BLACKLIST);
         this.tag(RITUAL_LOOT_BLACKLIST);
         this.tag(RITUAL_TRADE_BLACKLIST);
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/ItemTagProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/ItemTagProvider.java
@@ -30,6 +30,7 @@ public class ItemTagProvider extends IntrinsicHolderTagsProvider<Item> {
     public static TagKey<Item> BERRY_TAG = ItemTags.create(ResourceLocation.fromNamespaceAndPath("c", "fruits/berry"));
     public static final TagKey<Item> SUMMON_SHARDS_TAG = ItemTags.create(ArsNouveau.prefix("magic_shards"));
     public static TagKey<Item> JAR_ITEM_BLACKLIST = ItemTags.create(ArsNouveau.prefix("interact_jar_blacklist"));
+    public static TagKey<Item> JAR_ITEM_CAPTURE_BLACKLIST = ItemTags.create(ArsNouveau.prefix("jar_item_blacklist"));
     public static TagKey<Item> RITUAL_LOOT_BLACKLIST = ItemTags.create(ArsNouveau.prefix("ritual_loot_blacklist"));
     public static TagKey<Item> RITUAL_TRADE_BLACKLIST = ItemTags.create(ArsNouveau.prefix("ritual_trade_blacklist"));
     public static TagKey<Item> STORAGE_BLOCKS_QUARTZ = ItemTags.create(ResourceLocation.fromNamespaceAndPath("c", "storage_blocks/quartz"));

--- a/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualMobCapture.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/ritual/RitualMobCapture.java
@@ -6,6 +6,7 @@ import com.hollingsworth.arsnouveau.client.particle.ParticleUtil;
 import com.hollingsworth.arsnouveau.common.advancement.ANCriteriaTriggers;
 import com.hollingsworth.arsnouveau.common.block.MobJar;
 import com.hollingsworth.arsnouveau.common.block.tile.MobJarTile;
+import com.hollingsworth.arsnouveau.common.datagen.ItemTagProvider;
 import com.hollingsworth.arsnouveau.common.entity.EntityFlyingItem;
 import com.hollingsworth.arsnouveau.common.entity.Starbuncle;
 import com.hollingsworth.arsnouveau.common.lib.EntityTags;
@@ -98,10 +99,16 @@ public class RitualMobCapture extends AbstractRitual {
         if (e.getType().is(EntityTags.JAR_BLACKLIST)) {
             return false;
         }
+
         if (e instanceof PartEntity) {
             return false;
         }
-        return e instanceof LivingEntity livingEntity && !(e instanceof Player) && !((LivingEntity) e).isDeadOrDying();
+
+        if (e instanceof ItemEntity item && item.getItem().is(ItemTagProvider.JAR_ITEM_CAPTURE_BLACKLIST)) {
+            return false;
+        }
+
+        return e instanceof LivingEntity livingEntity && !(e instanceof Player) && !livingEntity.isDeadOrDying();
     }
 
     @Override


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->
adds a new item tag to disallow specific items from being captured by the Containment Ritual

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->
<img width="1439" height="266" alt="image" src="https://github.com/user-attachments/assets/05faa67d-d012-4b00-ab57-67d4ca3e2110" />
https://discord.com/channels/743298050222587978/743298050222587982/1514117635674214482

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
