### PR TITLE
Transfer the tag data onto the new dyed blockentity

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWololo.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/spell/effect/EffectWololo.java
@@ -5,11 +5,14 @@ import com.hollingsworth.arsnouveau.api.item.inv.InteractType;
 import com.hollingsworth.arsnouveau.api.item.inv.InventoryManager;
 import com.hollingsworth.arsnouveau.api.item.inv.SlotReference;
 import com.hollingsworth.arsnouveau.api.registry.ParticleTimelineRegistry;
-import com.hollingsworth.arsnouveau.api.spell.*;
+import com.hollingsworth.arsnouveau.api.spell.AbstractAugment;
+import com.hollingsworth.arsnouveau.api.spell.AbstractEffect;
+import com.hollingsworth.arsnouveau.api.spell.SpellContext;
+import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
+import com.hollingsworth.arsnouveau.api.spell.SpellStats;
 import com.hollingsworth.arsnouveau.api.spell.wrapped_caster.TileCaster;
 import com.hollingsworth.arsnouveau.api.util.IWololoable;
 import com.hollingsworth.arsnouveau.client.particle.ParticleColor;
-import com.hollingsworth.arsnouveau.common.crafting.recipes.IDyeable;
 import com.hollingsworth.arsnouveau.common.entity.debug.FixedStack;
 import com.hollingsworth.arsnouveau.common.mixin.MobAccessor;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentRandomize;
@@ -31,7 +34,11 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.TransientCraftingContainer;
-import net.minecraft.world.item.*;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.DyeItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.DyedItemColor;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -45,7 +52,11 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public class EffectWololo extends AbstractEffect {
     public static EffectWololo INSTANCE = new EffectWololo();
@@ -64,10 +75,11 @@ public class EffectWololo extends AbstractEffect {
         DyeItem dye = (DyeItem) dyeStack.getItem();
 
         if (rayTraceResult.getEntity() instanceof ItemEntity itemEntity) {
-            Item item = itemEntity.getItem().getItem();
-            if (item instanceof IDyeable iDyeable)
-                iDyeable.onDye(itemEntity.getItem(), dye.getDyeColor());
-            else if (item instanceof BlockItem blockItem) {
+            ItemStack item = itemEntity.getItem();
+
+            if (itemEntity.getItem().has(DataComponents.BASE_COLOR)) {
+                itemEntity.getItem().set(DataComponents.BASE_COLOR, dye.getDyeColor());
+            } else if (item.getItem() instanceof BlockItem blockItem) {
                 ItemStack result = getDyedResult((ServerLevel) world, makeContainer(dye, blockItem));
                 result.setCount(itemEntity.getItem().getCount());
                 if (!result.isEmpty() && result.getItem() instanceof BlockItem) {
@@ -75,9 +87,7 @@ public class EffectWololo extends AbstractEffect {
                 }
             }
 
-            if (itemEntity.getItem().has(DataComponents.BASE_COLOR)) {
-                itemEntity.getItem().set(DataComponents.BASE_COLOR, dye.getDyeColor());
-            }
+
         } else if (rayTraceResult.getEntity() instanceof LivingEntity living) {
             if (living instanceof Sheep sheep)
                 sheep.setColor(dye.getDyeColor());
@@ -87,11 +97,7 @@ public class EffectWololo extends AbstractEffect {
                         var dyeComponent = armorStack.get(DataComponents.DYED_COLOR);
                         if (dyeComponent != null) {
                             armorStack.set(DataComponents.DYED_COLOR, new DyedItemColor(dye.getDyeColor().getTextureDiffuseColor(), false));
-                        } else if (armorStack.getItem() instanceof IDyeable iDyeable) {
-                            iDyeable.onDye(armorStack, dye.getDyeColor());
-                        }
-
-                        if (armorStack.has(DataComponents.BASE_COLOR)) {
+                        } else if (armorStack.has(DataComponents.BASE_COLOR)) {
                             armorStack.set(DataComponents.BASE_COLOR, dye.getDyeColor());
                         }
                     }
@@ -112,7 +118,7 @@ public class EffectWololo extends AbstractEffect {
         if (spellContext.getCaster() instanceof TileCaster) {
             InventoryManager manager = spellContext.getCaster().getInvManager();
             SlotReference reference = manager.findItem(i -> i.getItem() instanceof DyeItem, InteractType.EXTRACT);
-            if (!reference.isEmpty()) {
+            if (!reference.isEmpty() && reference.getHandler() != null) {
                 return reference.getHandler().getStackInSlot(reference.getSlot());
             }
         } else {
@@ -132,7 +138,7 @@ public class EffectWololo extends AbstractEffect {
         BlockPos blockPos = rayTraceResult.getBlockPos();
         BlockEntity blockEntity = world.getBlockEntity(blockPos);
         if (blockEntity instanceof IWololoable tileToDye) {
-            ParticleColor color = spellStats.isRandomized() ? ParticleColor.makeRandomColor(255, 255, 255, shooter.getRandom()) : spellContext.getSpell().particleTimeline().get(ParticleTimelineRegistry.WOLOLO_TIMELINE).getColor();;
+            ParticleColor color = spellStats.isRandomized() ? ParticleColor.makeRandomColor(255, 255, 255, shooter.getRandom()) : spellContext.getSpell().particleTimeline().get(ParticleTimelineRegistry.WOLOLO_TIMELINE).getColor();
             tileToDye.setColor(color);
         } else {
             ItemStack dyeStack = getDye(shooter, spellStats, spellContext);
@@ -156,6 +162,14 @@ public class EffectWololo extends AbstractEffect {
                 blockItem = (BlockItem) result.getItem();
                 BlockState newState = blockItem.getBlock().withPropertiesOf(hitBlock);
                 world.setBlockAndUpdate(blockPos, newState);
+                //transfer tag if the block entity type is the same,
+                //for shulkers-like so they keep their inventory if dyed in-world
+                if (blockEntity != null) {
+                    var newBlockEntity = world.getBlockEntity(blockPos);
+                    if (newBlockEntity != null && newBlockEntity.getClass() == blockEntity.getClass()) {
+                        newBlockEntity.loadWithComponents(blockEntity.saveWithoutMetadata(world.registryAccess()), world.registryAccess());
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
 Only if they're the same type. Replaced IDyeable with component check

## Description

When used on a dyable block with a block entity, the spell places a new block but doesn't carry over the tile data.
This is a problem when the tile is an inventory container that has a dye recipe, such as shulker boxes.

Also replaces the deprecated interface check with the plain base color component set.

## Related Issues

Fixes "#2190"

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
