### PR TITLE
fix: triple discounts on tome getResolveCost

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/spell/SpellResolver.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/spell/SpellResolver.java
@@ -282,12 +282,9 @@ public class SpellResolver implements Cloneable {
     /**
      * Simulates the cost required to cast a spell
      */
-    // TODO: Remove backwards compat for SpellCostCalcEvent
     public int getResolveCost() {
         int cost = spellContext.getSpell().getCost() - getPlayerDiscounts(spellContext.getUnwrappedCaster(), spell, spellContext.getCasterTool());
-        SpellCostCalcEvent event = new SpellCostCalcEvent(spellContext, cost);
-        NeoForge.EVENT_BUS.post(event);
-        SpellCostCalcEvent.Pre preEvent = new SpellCostCalcEvent.Pre(spellContext, event.currentCost);
+        SpellCostCalcEvent.Pre preEvent = new SpellCostCalcEvent.Pre(spellContext, cost);
         NeoForge.EVENT_BUS.post(preEvent);
         cost = Math.max(0, preEvent.currentCost);
         return cost;

--- a/src/main/java/com/hollingsworth/arsnouveau/common/event/ArsEvents.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/event/ArsEvents.java
@@ -29,8 +29,6 @@ public class ArsEvents {
             int maxMana = ManaUtil.getMaxMana(livingCaster.player);
             if (e.currentCost > maxMana) {
                 e.currentCost = maxMana;
-            } else {
-                e.currentCost /= 2;
             }
         }
     }


### PR DESCRIPTION
## Description

event is posted twice and getPlayerDiscounts already applies halving

## Reason for Change

current behaviour is buggy, though not technically a problem since the player should always be able to cast tomes anyways.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
