### PR TITLE
Fixed Server hang with EntitySpellArrow.java by adding validation

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntitySpellArrow.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/entity/EntitySpellArrow.java
@@ -181,6 +181,15 @@ public class EntitySpellArrow extends Arrow {
         this.inGroundTime = 0;
         Vec3 vector3d2 = this.position();
         Vec3 vector3d3 = vector3d2.add(vec3);
+
+        if (!Double.isFinite(vector3d2.x) || !Double.isFinite(vector3d2.y) || !Double.isFinite(vector3d2.z)
+                || !Double.isFinite(vector3d3.x) || !Double.isFinite(vector3d3.y) || !Double.isFinite(vector3d3.z)
+                || Math.abs(vector3d2.x) > 1024 || Math.abs(vector3d2.y) > 1024 || Math.abs(vector3d2.z) > 1024
+                || Math.abs(vector3d3.x) > 1024 || Math.abs(vector3d3.y) > 1024 || Math.abs(vector3d3.z) > 1024) {
+            this.discard();
+            return;
+        }
+
         HitResult hitresult = this.level.clip(new ClipContext(vector3d2, vector3d3, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, this));
         if (hitresult.getType() != HitResult.Type.MISS) {
             vector3d3 = hitresult.getLocation();


### PR DESCRIPTION
Fixed Server hang with EntitySpellArrow.java by adding validation if the doubles are finite and within limits.

Fixes Server crash for [Project Crowbar SMP](projectcrowbar.com).

## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

( Awaiting owner to test changes )

## Checklist

- [X] I have tested my changes thoroughly
- [X] I have updated documentation if needed
