### PR TITLE
fix: various warp portal issues

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/PortalTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/PortalTile.java
@@ -63,7 +63,6 @@ public class PortalTile extends ModdedTile implements ITickable, ITooltipProvide
                 return;
             }
             Vec3 vec3 = e.position;
-            Networking.sendToNearbyClient(serverWorld, e, new PacketWarpPosition(e.getId(), e.getX(), e.getY(), e.getZ(), rotationVec.x, rotationVec.y));
             var particlePos = warpPos.getCenter();
             serverLevel.sendParticles(ParticleTypes.PORTAL, particlePos.x, particlePos.y, particlePos.z,
                     4, (serverWorld.random.nextDouble() - 0.5D) * 2.0D, -serverWorld.random.nextDouble(), (serverWorld.random.nextDouble() - 0.5D) * 2.0D, 0.1f);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/PortalTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/PortalTile.java
@@ -63,10 +63,10 @@ public class PortalTile extends ModdedTile implements ITickable, ITooltipProvide
                 return;
             }
             Vec3 vec3 = e.position;
-            Networking.sendToNearbyClient(serverWorld, e, new PacketWarpPosition(e.getId(), e.getX() + 0.5, e.getY(), e.getZ() + 0.5, rotationVec.x, rotationVec.y));
-            serverLevel.sendParticles(ParticleTypes.PORTAL, warpPos.getX(), warpPos.getY() + 1, warpPos.getZ(),
+            Networking.sendToNearbyClient(serverWorld, e, new PacketWarpPosition(e.getId(), e.getX(), e.getY(), e.getZ(), rotationVec.x, rotationVec.y));
+            var particlePos = warpPos.getCenter();
+            serverLevel.sendParticles(ParticleTypes.PORTAL, particlePos.x, particlePos.y, particlePos.z,
                     4, (serverWorld.random.nextDouble() - 0.5D) * 2.0D, -serverWorld.random.nextDouble(), (serverWorld.random.nextDouble() - 0.5D) * 2.0D, 0.1f);
-            serverWorld.getChunkSource().addRegionTicket(TicketType.PORTAL, new ChunkPos(warpPos), 3, warpPos);
             e.level().gameEvent(GameEvent.TELEPORT, vec3, GameEvent.Context.of(e));
         }
     }
@@ -117,7 +117,8 @@ public class PortalTile extends ModdedTile implements ITickable, ITooltipProvide
                         continue;
                     if (dimID != null && PortalTile.teleportEntityTo(e, getServerLevel(dimID, serverLevel), this.warpPos, rotationVec) != null) {
                         level.playSound(null, warpPos, SoundEvents.ILLUSIONER_MIRROR_MOVE, SoundSource.NEUTRAL, 1.0f, 1.0f);
-                        serverLevel.sendParticles(ParticleTypes.PORTAL, warpPos.getX(), warpPos.getY() + 1, warpPos.getZ(),
+                        var particlePos = warpPos.getCenter();
+                        serverLevel.sendParticles(ParticleTypes.PORTAL, particlePos.x, particlePos.y, particlePos.z,
                                 4, (this.level.random.nextDouble() - 0.5D) * 2.0D, -this.level.random.nextDouble(), (this.level.random.nextDouble() - 0.5D) * 2.0D, 0.1f);
                     }
                 }
@@ -135,19 +136,23 @@ public class PortalTile extends ModdedTile implements ITickable, ITooltipProvide
     }
 
     @Nullable
-    public static Entity teleportEntityTo(Entity entity, @Nullable Level targetWorld, BlockPos target, Vec2 rotationVec) {
-        if (targetWorld == null) {
+    public static Entity teleportEntityTo(Entity entity, @Nullable Level world, BlockPos target, Vec2 rotationVec) {
+        if (!(world instanceof ServerLevel targetWorld)) {
             return entity;
         }
+
+        Vec3 destination = new Vec3(target.getX() + 0.5, target.getY(), target.getZ() + 0.5);
         if (entity.getCommandSenderWorld().dimension() == targetWorld.dimension()) {
             // Check if the target block is a portal, if so, don't teleport
-            if ((targetWorld.getBlockState(target).getBlock() instanceof PortalBlock)) {
+            if (targetWorld.getBlockState(target).getBlock() instanceof PortalBlock) {
                 return entity;
             }
+
+            targetWorld.getChunkSource().addRegionTicket(TicketType.PORTAL, new ChunkPos(target), 3, target);
             var rotX = rotationVec != null ? rotationVec.x : entity.getXRot();
             var rotY = rotationVec != null ? rotationVec.y : entity.getYRot();
-            Networking.sendToNearbyClient(targetWorld, entity, new PacketWarpPosition(entity.getId(), target.getX() + 0.5, target.getY(), target.getZ() + 0.5, rotX, rotY));
-            entity.teleportTo(target.getX() + 0.5, target.getY(), target.getZ() + 0.5);
+            Networking.sendToNearbyClient(targetWorld, entity, new PacketWarpPosition(entity.getId(), destination.x,destination.y, destination.z, rotX, rotY));
+            entity.teleportTo(destination.x, destination.y, destination.z);
             entity.setXRot(rotX);
             entity.setYRot(rotY);
 
@@ -156,6 +161,7 @@ public class PortalTile extends ModdedTile implements ITickable, ITooltipProvide
                 ((ServerChunkCache) entity.getCommandSenderWorld().getChunkSource()).broadcast(entity, new ClientboundSetPassengersPacket(entity));
                 Entity controller = entity.getControllingPassenger();
                 if (controller != entity && controller instanceof ServerPlayer player && !(controller instanceof FakePlayer)) {
+                    //noinspection ConstantValue
                     if (player.connection != null) {
                         //Force sync the fact that the vehicle moved to the client that is controlling it
                         // so that it makes sure to use the correct positions when sending move packets
@@ -166,9 +172,10 @@ public class PortalTile extends ModdedTile implements ITickable, ITooltipProvide
             }
             return entity;
         }
-        Vec3 destination = new Vec3(target.getX() + 0.5, target.getY(), target.getZ() + 0.5);
+
+        targetWorld.getChunkSource().addRegionTicket(TicketType.PORTAL, new ChunkPos(target), 3, target);
         //Note: We grab the passengers here instead of in placeEntity as changeDimension starts by removing any passengers
-        return entity.changeDimension(new DimensionTransition((ServerLevel) targetWorld, destination, new Vec3(0, 0, 0), rotationVec.y, rotationVec.x, false, DimensionTransition.DO_NOTHING));
+        return entity.changeDimension(new DimensionTransition(targetWorld, destination, Vec3.ZERO, rotationVec.y, rotationVec.x, false, DimensionTransition.DO_NOTHING));
     }
 
     @Override


### PR DESCRIPTION
## Description

fixes various issues:
- particles being unusually offset 1 block up and in a corner
- ticket not being added for Blink
- removes duplicated PacketWarpPosition (also fixing x+0.5, z+0.5 visual offset)

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
