### PR TITLE
fix: remove Iron Golems from Drygmy blacklist

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/datagen/EntityTagProvider.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/datagen/EntityTagProvider.java
@@ -30,7 +30,7 @@ public class EntityTagProvider extends EntityTypeTagsProvider {
         this.tag(EntityTags.REWIND_BLACKLIST).addTags(Tags.EntityTypes.BOSSES);
         this.tag(EntityTags.DISINTEGRATION_BLACKLIST);
         this.tag(EntityTags.DISINTEGRATION_WHITELIST);
-        this.tag(EntityTags.DRYGMY_BLACKLIST).add(EntityType.IRON_GOLEM);
+        this.tag(EntityTags.DRYGMY_BLACKLIST);
         this.tag(EntityTags.MAGIC_FIND)
                 .add(ModEntities.STARBUNCLE_TYPE.get(), ModEntities.ENTITY_DRYGMY.get(),
                         ModEntities.WHIRLISPRIG_TYPE.get(),


### PR DESCRIPTION
## Description

Removes Iron Golems from the default Drygmy blacklist.

## Reason for Change

Iron Golems have been discriminated against for long enough. It takes longer to set up a Drygmy farm than it does to set up an Iron Farm. I believe it's time to finally release them from the tag. 

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
