### PR TITLE
fix: add memoizer to enchanting apparatus recipe lookup

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/EnchantingApparatusTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/EnchantingApparatusTile.java
@@ -13,6 +13,7 @@ import com.hollingsworth.arsnouveau.common.datagen.ItemTagProvider;
 import com.hollingsworth.arsnouveau.common.network.HighlightAreaPacket;
 import com.hollingsworth.arsnouveau.common.network.Networking;
 import com.hollingsworth.arsnouveau.common.network.PacketOneShotAnimation;
+import com.hollingsworth.arsnouveau.common.util.Memoizer;
 import com.hollingsworth.arsnouveau.setup.registry.BlockRegistry;
 import com.hollingsworth.arsnouveau.setup.registry.SoundRegistry;
 import net.minecraft.core.BlockPos;
@@ -25,6 +26,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -41,6 +43,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 public class EnchantingApparatusTile extends SingleItemTile implements Container, IPedestalMachine, ITickable, GeoBlockEntity {
     private int counter;
@@ -140,8 +143,11 @@ public class EnchantingApparatusTile extends SingleItemTile implements Container
         return pedestalItems;
     }
 
+    record GetRecipeInput(Level level, ItemStack stack, ApparatusRecipeInput input) {};
+    Function<GetRecipeInput, RecipeHolder<? extends IEnchantingRecipe>> memo = Memoizer.memoize(input -> IEnchantingRecipe.getRecipe(input.level, input.input));
+
     public IEnchantingRecipe getRecipe(ItemStack stack, @Nullable Player playerEntity) {
-        var recipe = IEnchantingRecipe.getRecipe(level, new ApparatusRecipeInput(stack, getPedestalItems(), playerEntity));
+        var recipe = memo.apply(new GetRecipeInput(level, stack, new ApparatusRecipeInput(stack, getPedestalItems(), playerEntity)));
         return recipe != null ? recipe.value() : null;
     }
 


### PR DESCRIPTION
## Description

Memoize IEnchantingRecipe lookup

## Reason for Change

Enchanting Apparatus currently iterates through all IEnchantingRecipe every tick while it's crafting. This doesn't scale well when tick-accelerated or when lots of apparatus' are crafting simultaneously.

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
