### PR TITLE
Fix "Connection Lost" crash caused by invalid items in loot table simulation

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/api/registry/AlakarkinosConversionRegistry.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/api/registry/AlakarkinosConversionRegistry.java
@@ -134,6 +134,9 @@ public class AlakarkinosConversionRegistry {
                         .create(LootContextParamSets.CHEST);
                 for (int i = 0; i < 600; i++) {
                     for (ItemStack random : lootTable.getRandomItems(lootParams)) {
+                        if(random.isEmpty()){
+                            continue;
+                        }
                         drops.put(random, drops.getInt(random) + random.getCount());
                     }
                 }


### PR DESCRIPTION
1. Reproduction Steps
The game crashes and kicks the player to the main menu with a "Connection Lost" error when loading a world (especially noticeable when loading a Superflat world).
To reproduce the issue, the following dependencies and mods were used in the development environment:
```gradle
implementation(annotationProcessor("io.github.llamalad7:mixinextras-neoforge:0.5.3"))
localRuntime 'maven.modrinth:iGEl6Crx:EAjbdreT' //biolith-neoforge-3.0.14.jar
localRuntime 'maven.modrinth:twkfQtEc:cvwb1lxE' //moonlight-neoforge-1.21.1-3.1.1.jar
localRuntime 'maven.modrinth:kjZCvAn6:bcszfrVc' //nomansland-1.5.12.jar
localRuntime 'maven.modrinth:qnQsVE2z:PRtPti1t' //Quark-4.1-474.jar
localRuntime 'maven.modrinth:fFEIiSDQ:Ud6brJoG' //supplementaries-neoforge-1.21.1-3.8.2
localRuntime 'maven.modrinth:MVARlG2f:9GjNW2Gf' //Zeta-1.1-40.jar
```
2. Root Cause
The computeLootDrops method uses a Monte Carlo simulation (looping 600 times) to pre-calculate loot probabilities. In complex modpack environments, this simulation can occasionally generate invalid items (such as minecraft:air with 0 count) due to mod conflicts or failed item generation.
Because there was no validation, these invalid items were cached. Later, when the recipe was synced to the client via the toNetwork method, the STREAM_CODEC failed to encode the air item, causing a crash.
3. Fix
Added a simple isEmpty() check inside the simulation loop to filter out invalid items before they are added to the drops map.
```java
for (ItemStack random : lootTable.getRandomItems(lootParams)) {
    // Filter out air or empty item stacks to prevent network sync crashes
    if (random.isEmpty()) {
        continue;
    }
    drops.put(random, drops.getInt(random) + random.getCount());
}
```