### PR TITLE
Update input handling

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
@@ -19,7 +19,6 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
-import net.neoforged.neoforge.client.event.InputEvent;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 
 import static com.hollingsworth.arsnouveau.api.util.StackUtil.getHeldSpellbook;
@@ -123,16 +122,6 @@ public class KeyHandler {
                     }
                 }
             }
-        }
-    }
-
-    @SubscribeEvent
-    public static void mouseEvent(final InputEvent.MouseButton.Post event) {
-
-        if (MINECRAFT.player == null || event.getAction() != 1)
-            return;
-        if (MINECRAFT.screen instanceof GuiRadialMenu<?> screen) {
-            screen.mouseClicked(0, 0, 0);
         }
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/keybindings/KeyHandler.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 
@@ -30,32 +31,30 @@ public class KeyHandler {
             ModKeyBindings.HEAD_CURIO_HOTKEY
     };
 
-    public static void checkKeysPressed(int key) {
-        checkCurioHotkey(key);
-        if (key == ModKeyBindings.FAMILIAR_TOGGLE.getKey().getValue() && !ModKeyBindings.FAMILIAR_TOGGLE.isUnbound()) {
+    public static void checkKeysPressed() {
+        checkCurioHotkey();
+        while (ModKeyBindings.FAMILIAR_TOGGLE.consumeClick()) {
             Networking.sendToServer(new PacketToggleFamiliar());
         }
-        if (key == ModKeyBindings.OPEN_RADIAL_HUD.getKey().getValue() && !ModKeyBindings.OPEN_RADIAL_HUD.isUnbound()) {
+        boolean radialKeyPressed = ModKeyBindings.OPEN_RADIAL_HUD.consumeClick();
+        if (radialKeyPressed) {
             if (MINECRAFT.screen instanceof GuiRadialMenu) {
                 MINECRAFT.player.closeContainer();
-                return;
             }
         }
-        checkCasterKeys(key);
+        checkCasterKeys(radialKeyPressed);
     }
 
-    public static void checkCasterKeys(int key) {
-        if (key == -1)
-            return;
+    public static void checkCasterKeys(boolean radialKeyPressed) {
         Player player = MINECRAFT.player;
         ItemStack radialStack = StackUtil.getHeldRadial(player);
-        if (radialStack.getItem() instanceof IRadialProvider radialProvider && key == ((IRadialProvider) radialStack.getItem()).forKey()) {
-            if (MINECRAFT.screen == null) {
-                radialProvider.onRadialKeyPressed(radialStack, player);
-                return;
-            } else if (MINECRAFT.screen instanceof GuiRadialMenu) {
-                MINECRAFT.player.closeContainer();
-                return;
+        if (radialStack.getItem() instanceof IRadialProvider radialProvider) {
+            if (radialKeyPressed) {
+                if (MINECRAFT.screen == null) {
+                    radialProvider.onRadialKeyPressed(radialStack, player);
+                } else if (MINECRAFT.screen instanceof GuiRadialMenu) {
+                    MINECRAFT.player.closeContainer();
+                }
             }
         }
 
@@ -68,18 +67,16 @@ public class KeyHandler {
         if (!(stack.getItem() instanceof ISpellHotkeyListener hotkeyListener))
             return;
 
-        if (key == ModKeyBindings.NEXT_SLOT.getKey().getValue()) {
+        while (ModKeyBindings.NEXT_SLOT.consumeClick()) {
             sendHotkeyPacket(PacketHotkeyPressed.Key.NEXT);
-            return;
         }
 
-        if (key == ModKeyBindings.PREVIOUS_SLOT.getKey().getValue()) {
+        while (ModKeyBindings.PREVIOUS_SLOT.consumeClick()) {
             sendHotkeyPacket(PacketHotkeyPressed.Key.PREVIOUS);
-            return;
         }
 
 
-        if (key == ModKeyBindings.OPEN_BOOK.getKey().getValue()) {
+        if (ModKeyBindings.OPEN_BOOK.consumeClick()) {
             if (MINECRAFT.screen instanceof GuiSpellBook && !((GuiSpellBook) MINECRAFT.screen).spellNameBox.isFocused()) {
                 MINECRAFT.player.closeContainer();
                 return;
@@ -102,15 +99,15 @@ public class KeyHandler {
                 }
             }
         }
-        int slot = ModKeyBindings.usedQuickSlot(key);
+        int slot = ModKeyBindings.usedQuickSlot();
         if (slot != -1) {
             Networking.sendToServer(new PacketQuickCast(slot));
         }
     }
 
-    public static void checkCurioHotkey(int keyMapping) {
+    public static void checkCurioHotkey() {
         for (KeyMapping mapping : CURIO_MAPPINGS) {
-            if (mapping.getKey().getValue() == keyMapping) {
+            if (mapping.consumeClick()) {
                 IItemHandlerModifiable handler = CuriosUtil.getAllWornItems(MINECRAFT.player);
                 if (handler == null)
                     return;
@@ -125,7 +122,6 @@ public class KeyHandler {
                         }
                     }
                 }
-                return;
             }
         }
     }
@@ -137,20 +133,16 @@ public class KeyHandler {
             return;
         if (MINECRAFT.screen instanceof GuiRadialMenu<?> screen) {
             screen.mouseClicked(0, 0, 0);
-            return;
         }
-        if (MINECRAFT.screen == null)
-            checkKeysPressed(event.getButton());
     }
 
     @SubscribeEvent
-    public static void keyEvent(final InputEvent.Key event) {
-
-        if (MINECRAFT.player == null || event.getAction() != 1)
+    public static void onClientTick(ClientTickEvent.Post event) {
+        if (MINECRAFT.player == null)
             return;
         if (MINECRAFT.screen == null || MINECRAFT.screen instanceof GuiRadialMenu)
-            checkKeysPressed(event.getKey());
-        if (event.getKey() == Minecraft.getInstance().options.keyJump.getKey().getValue()) {
+            checkKeysPressed();
+        while (Minecraft.getInstance().options.keyJump.consumeClick()) {
             if (Minecraft.getInstance().player != null
                     && !Minecraft.getInstance().player.onGround()
                     && CuriosUtil.hasItem(Minecraft.getInstance().player, ItemsRegistry.JUMP_RING.get())

--- a/src/main/java/com/hollingsworth/arsnouveau/client/registry/ModKeyBindings.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/registry/ModKeyBindings.java
@@ -39,9 +39,9 @@ public class ModKeyBindings {
     public static final KeyMapping QC_9 = new KeyMapping("key.ars_nouveau.qc9", -1, CATEGORY);
     public static final KeyMapping QC_10 = new KeyMapping("key.ars_nouveau.qc10", -1, CATEGORY);
 
-    public static int usedQuickSlot(int key) {
+    public static int usedQuickSlot() {
         for (QuickSlot q : QuickSlot.VALUES) {
-            if (q.key().getKey().getValue() == key) {
+            if (q.key().consumeClick()) {
                 return q.slot;
             }
         }


### PR DESCRIPTION
## Description

Update input handling to the recommended approach listed in the neoforge docs for MC 1.21.1.

## Reason for Change

Currently, Ars Nouveau uses `InputEvent` to handle input, which the neoforge docs [discourage](https://docs.neoforged.net/docs/1.21.1/misc/keymappings/#within-the-game). In practice this means that mods that add controller support (I specifically tested Controlify and MidnightControls) cannot execute Ars Nouveau keybinds. With this PR both mods should work, but I only verified this for MidnightControls because I liked the mod more when I tried it out and didn't reinstall Controlify. I initially implemented the changes for 5.12.1 and tested them on a server (since the changes are client-side only this shouldn't make a difference and I won't check the check mark below either). I didn't notice any issues with that setup while playing there for the last week.

Note that I'm not that familiar with Minecraft modding and Java, but I'm still pretty sure that this should work. In the second of the two commits I removed the `mouseEvent` handler, because I didn't notice any changes without it. I don't understand what the `screen.mouseClicked(0, 0, 0);` was for, so I would really appreciate if you could take a look at that.

Thank you for your great work and have a nice day

## Related Issues

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated documentation if needed
