### PR TITLE
fix: throttle repeated insert attempts into full storage networks

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ControllerInv.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/ControllerInv.java
@@ -25,6 +25,10 @@ public class ControllerInv extends CombinedHandlerInv implements IMapInventory {
 
     @Override
     public ItemStack insertStack(ItemStack stack, boolean simulate) {
+        if (stack.isEmpty() || controllerTile.hasFailedInsertThisTick(stack)) {
+            return stack;
+        }
+        int startCount = stack.getCount();
         var validRepositories = preferredForStack(stack, false);
         // Prefer inserting into existing stacks first, splitting across as many inventories as needed
         for (SortResult connectedRepository : validRepositories) {
@@ -50,6 +54,11 @@ public class ControllerInv extends CombinedHandlerInv implements IMapInventory {
             }
         }
 
+        // Only a complete failure proves the network has no room for this item; a partial insert must not
+        // poison the memo, or a simulated partial insert would block the real insert that follows it.
+        if (stack.getCount() == startCount) {
+            controllerTile.recordFailedInsert(stack);
+        }
         return stack;
     }
 

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
@@ -365,7 +365,7 @@ public class MobJarTile extends ModdedTile implements ITickable, IDispellable, I
         @Override
         public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
             var result = inner.insertItem(slot, stack, simulate);
-            if (!simulate) {
+            if (!simulate && result.getCount() != stack.getCount()) {
                 var entity = tile.getEntity();
                 if (entity != null) {
                     tile.entityTag = tile.saveEntityToTag(entity);
@@ -377,7 +377,7 @@ public class MobJarTile extends ModdedTile implements ITickable, IDispellable, I
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
             var result = inner.extractItem(slot, amount, simulate);
-            if (!simulate) {
+            if (!simulate && !result.isEmpty()) {
                 var entity = tile.getEntity();
                 if (entity != null) {
                     tile.entityTag = tile.saveEntityToTag(entity);

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RepositoryCatalogTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/RepositoryCatalogTile.java
@@ -63,6 +63,44 @@ public class RepositoryCatalogTile extends ModdedTile implements ITooltipProvide
     private int openDrawer = 0;
     private int drawerTicks = 0;
 
+    // Automation mods call ControllerInv#insertItem once per slot (simulated or not), and every call
+    // scans all connected repositories. When the network is full that is O(slots^2) per transfer attempt
+    // and can stall the tick thread, so remember stacks that failed to insert and fail fast until next tick.
+    private long failedInsertGameTime = -1L;
+    private final List<ItemStack> failedInserts = new ArrayList<>();
+    private static final int MAX_FAILED_INSERT_CACHE = 64;
+
+    /**
+     * Whether an insert of this item already completely failed during the current game tick.
+     * Repositories cannot gain space from an insert attempt, so retrying within the same tick is wasted work.
+     */
+    public boolean hasFailedInsertThisTick(ItemStack stack) {
+        if (level == null || failedInsertGameTime != level.getGameTime()) {
+            return false;
+        }
+        for (ItemStack failed : failedInserts) {
+            if (ItemStack.isSameItemSameComponents(failed, stack)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void recordFailedInsert(ItemStack stack) {
+        if (level == null) {
+            return;
+        }
+        long gameTime = level.getGameTime();
+        if (failedInsertGameTime != gameTime) {
+            failedInsertGameTime = gameTime;
+            failedInserts.clear();
+        }
+        if (failedInserts.size() >= MAX_FAILED_INSERT_CACHE || hasFailedInsertThisTick(stack)) {
+            return;
+        }
+        failedInserts.add(stack.copyWithCount(1));
+    }
+
     public RepositoryCatalogTile(BlockPos pos, BlockState state) {
         super(BlockRegistry.REPOSITORY_CONTROLLER_TILE, pos, state);
     }

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/StorageLecternTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/StorageLecternTile.java
@@ -72,6 +72,14 @@ public class StorageLecternTile extends ModdedTile implements MenuProvider, ITic
     IItemHandler lecternInvWrapper;
     public boolean powered;
 
+    // Automation mods call LecternInvWrapper#insertItem once per wrapper slot, and every call scans the
+    // entire storage network. When the network is full that is O(slots^2) per transfer attempt and can
+    // stall the tick thread, so remember stacks that failed to insert and fail them fast until next tick.
+    private long failedInsertGameTime = -1L;
+    private final List<ItemStack> failedInserts = new ArrayList<>();
+    private static final int MAX_FAILED_INSERT_CACHE = 64;
+    private boolean pushingStack;
+
 
     public StorageLecternTile(BlockPos pos, BlockState state) {
         super(BlockRegistry.CRAFTING_LECTERN_TILE.get(), pos, state);
@@ -230,8 +238,22 @@ public class StorageLecternTile extends ModdedTile implements MenuProvider, ITic
         if (stack == null) {
             return null;
         }
+        if (pushingStack) {
+            // A connected inventory routed this insertion back into the lectern; inserting again would recurse forever.
+            return stack;
+        }
+        boolean wholeNetwork = tab == null || tab.isEmpty();
+        if (wholeNetwork && hasFailedInsertThisTick(stack.getStack())) {
+            return stack;
+        }
         ItemStack copyStack = stack.getActualStack().copy();
-        MultiInsertReference reference = getInvManager(tab).insertStackWithReference(stack.getActualStack());
+        MultiInsertReference reference;
+        pushingStack = true;
+        try {
+            reference = getInvManager(tab).insertStackWithReference(stack.getActualStack());
+        } finally {
+            pushingStack = false;
+        }
         ItemStack remaining = reference.getRemainder();
         if (!reference.isEmpty()) {
             addInsertTasks(copyStack, reference);
@@ -239,7 +261,41 @@ public class StorageLecternTile extends ModdedTile implements MenuProvider, ITic
         if (remaining.isEmpty()) {
             return null;
         }
+        if (wholeNetwork) {
+            recordFailedInsert(remaining);
+        }
         return new StoredItemStack(remaining);
+    }
+
+    /**
+     * Whether a whole-network insert of this item already failed during the current game tick.
+     * Inventories cannot gain space from an insert attempt, so retrying within the same tick is wasted work.
+     */
+    private boolean hasFailedInsertThisTick(ItemStack stack) {
+        if (level == null || failedInsertGameTime != level.getGameTime()) {
+            return false;
+        }
+        for (ItemStack failed : failedInserts) {
+            if (ItemStack.isSameItemSameComponents(failed, stack)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void recordFailedInsert(ItemStack remaining) {
+        if (level == null) {
+            return;
+        }
+        long gameTime = level.getGameTime();
+        if (failedInsertGameTime != gameTime) {
+            failedInsertGameTime = gameTime;
+            failedInserts.clear();
+        }
+        if (failedInserts.size() >= MAX_FAILED_INSERT_CACHE || hasFailedInsertThisTick(remaining)) {
+            return;
+        }
+        failedInserts.add(remaining.copyWithCount(1));
     }
 
     public ItemStack pushStack(ItemStack itemstack, @Nullable String tab) {


### PR DESCRIPTION
Automation mods (Modular Routers, Integrated Tunnels) insert via ItemHandlerHelper, which tries every slot of the target handler in a loop. LecternInvWrapper and ControllerInv ignore the slot argument and scan the entire connected network on every call, so a full network turned one transfer attempt into (total slots)^2 insert calls per tick and hung the server tick thread.

- StorageLecternTile: remember item types whose whole-network insert failed during the current game tick and fail them fast until next tick; also guard pushStack against reentrancy in case a connected inventory routes an insertion back into the lectern.
- RepositoryCatalogTile/ControllerInv: same per-tick failure memo, including simulated inserts (only complete failures are recorded, so a partial simulated insert can't block the real insert that follows).
- MobJarTile: only re-serialize the jarred entity when an insert/extract actually moved an item, instead of on every non-simulated call.

Disclaimer: I used AI to write the patch

## Description

Fixed an issue where inserting into a storage lectern connected to many inventories or repositories via automation when full would hang a server instantly or corrupt a solo world.

## Reason for Change

The bug deadlocked my small dedicated server and decided to fix it for everyone.

## Related Issues

Fixes #2235 

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

Tested the patch on my server for a full week now and it seems to be stable and fully fixed the bug.
Before making the change as soon as I would join the server it would freeze entirely. With the patch no freeze at all. Also profiled before and after with spark. Conclusion is a major performance improvement.

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated documentation if needed
