### PR TITLE
fix: remove per-tick containment jar visibility raycasts

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/MobJarRenderer.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/client/renderer/tile/MobJarRenderer.java
@@ -26,11 +26,6 @@ public class MobJarRenderer implements BlockEntityRenderer<MobJarTile> {
     }
 
     @Override
-    public boolean shouldRender(MobJarTile blockEntity, Vec3 cameraPos) {
-        return blockEntity.isVisible && BlockEntityRenderer.super.shouldRender(blockEntity, cameraPos);
-    }
-
-    @Override
     public void render(MobJarTile pBlockEntity, float pPartialTick, PoseStack pPoseStack, MultiBufferSource pBufferSource, int pPackedLight, int pPackedOverlay) {
         Entity entity = pBlockEntity.getEntity();
         if (entity == null)

--- a/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/block/tile/MobJarTile.java
@@ -11,7 +11,6 @@ import com.hollingsworth.arsnouveau.common.lib.EntityTags;
 import com.hollingsworth.arsnouveau.common.util.Log;
 import com.hollingsworth.arsnouveau.setup.registry.BlockRegistry;
 import com.hollingsworth.arsnouveau.setup.registry.DataComponentRegistry;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
@@ -22,13 +21,9 @@ import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.animal.Bee;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.HitResult;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.CollisionContext;
 import net.neoforged.neoforge.capabilities.EntityCapability;
 import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
@@ -48,8 +43,6 @@ public class MobJarTile extends ModdedTile implements ITickable, IDispellable, I
 
     private CompoundTag extraDataTag;
 
-    public boolean isVisible = true;
-
     public MobJarTile(BlockPos pos, BlockState state) {
         super(BlockRegistry.MOB_JAR_TILE, pos, state);
     }
@@ -65,42 +58,6 @@ public class MobJarTile extends ModdedTile implements ITickable, IDispellable, I
 
                 if (cachedEntity instanceof Mob mob && !(mob instanceof Bee)) {
                     mob.getLookControl().tick();
-                }
-
-                this.isVisible = false;
-                var entity = this.getEntity();
-                if (entity != null) {
-                    var camera = Minecraft.getInstance().gameRenderer.getMainCamera();
-
-                    var startPos = camera.getPosition();
-                    if (startPos.distanceToSqr(this.getBlockPos().getCenter()) <= 64 * 64) {
-                        var aabb = entity.getBoundingBoxForCulling();
-                        for (var passenger : entity.getPassengers()) {
-                            aabb = aabb.minmax(passenger.getBoundingBoxForCulling());
-                        }
-
-                        if (Double.isFinite(aabb.minX) && Double.isFinite(aabb.minY) && Double.isFinite(aabb.minZ)
-                                && Double.isFinite(aabb.maxX) && Double.isFinite(aabb.maxY) && Double.isFinite(aabb.maxZ)) {
-                            for (var endPos : new Vec3[]{
-                                    new Vec3(aabb.minX, aabb.minY, aabb.minZ),
-                                    new Vec3(aabb.minX, aabb.minY, aabb.maxZ),
-                                    new Vec3(aabb.minX, aabb.maxY, aabb.minZ),
-                                    new Vec3(aabb.minX, aabb.maxY, aabb.maxZ),
-                                    new Vec3(aabb.maxX, aabb.minY, aabb.minZ),
-                                    new Vec3(aabb.maxX, aabb.minY, aabb.maxZ),
-                                    new Vec3(aabb.maxX, aabb.maxY, aabb.minZ),
-                                    new Vec3(aabb.maxX, aabb.maxY, aabb.maxZ),
-                            }) {
-                                var result = level.clip(new ClipContext(startPos, endPos, ClipContext.Block.VISUAL, ClipContext.Fluid.NONE, CollisionContext.empty()));
-                                if (result.getType() == HitResult.Type.MISS || this.getBlockPos() == result.getBlockPos()) {
-                                    this.isVisible = true;
-                                    break;
-                                }
-                            }
-                        } else {
-                            this.isVisible = true;
-                        }
-                    }
                 }
             }
             dispatchBehavior((behavior) -> {


### PR DESCRIPTION
## Description

Removes the custom per-tick line-of-sight check used to decide whether entities inside filled Containment Jars should render.

`MobJarTile` no longer raycasts toward all eight corners of the contained entity's culling box. `MobJarRenderer` now relies on the standard block entity rendering visibility path.

## Reason for Change

Each filled Containment Jar within 64 blocks could perform up to eight `Level.clip` calls every client tick. The cost scales with the number of jars and the complexity of blocks between the player and the jars, even when the player is not looking toward them.

This caused the severe client-side frame drops reported in #2174. Removing the custom visibility raycasts eliminates that per-tick cost while leaving contained entity state, jar interactions, behavior ticking, the default render distance, and the jar's visual shape unchanged.

## Related Issues

Fixes #2174

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

I tested the new JAR on the server I play on with my friends. It fixed the stuttering and frame drops described in #2174. I also checked that entities in the jars still stop rendering when I move far enough away.

- [ ] Tested in single-player
- [x] Tested in multiplayer (LAN)
- [x] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated documentation if needed (no user-facing documentation changes are required)
