### PR TITLE
perf: ignore AN's fake players when checking for void jar

### DIFF
--- a/src/main/java/com/hollingsworth/arsnouveau/common/items/VoidJar.java
+++ b/src/main/java/com/hollingsworth/arsnouveau/common/items/VoidJar.java
@@ -1,5 +1,6 @@
 package com.hollingsworth.arsnouveau.common.items;
 
+import com.hollingsworth.arsnouveau.api.ANFakePlayer;
 import com.hollingsworth.arsnouveau.api.documentation.DocClientUtils;
 import com.hollingsworth.arsnouveau.api.item.IScribeable;
 import com.hollingsworth.arsnouveau.common.items.data.VoidJarData;
@@ -39,6 +40,9 @@ public class VoidJar extends ModItem implements IScribeable {
     }
 
     public static boolean tryVoiding(Player player, ItemStack pickingUp) {
+        if (player instanceof ANFakePlayer) {
+            return false;
+        }
         NonNullList<ItemStack> list = player.inventory.items;
         for (ItemStack jar : list) {
             if (jar.getItem() instanceof VoidJar voidJar) {


### PR DESCRIPTION
## Description

ignore ANFakePlayer when checking for void jar presence in pickup event

## Reason for Change

improves performance for automated setups using the Pickup glyph with runes or turrets, since they don't fill in the fake palyer's inventory anyways

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
